### PR TITLE
feat(task): 조회 API 구현

### DIFF
--- a/src/main/java/com/example/workmanagement/domain/task/domain/model/Task.java
+++ b/src/main/java/com/example/workmanagement/domain/task/domain/model/Task.java
@@ -25,7 +25,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
-@Table
+@Table(name = "tasks")
 @EntityListeners(AuditingEntityListener.class)
 @Accessors(fluent = true)
 @Getter

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/TaskController.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/TaskController.java
@@ -36,6 +36,7 @@ public class TaskController {
     @Operation(summary = "업무 상세 조회", description = "특정 프로젝트의 업무 상세 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<TaskDetailResult>> getTask(
 
+            @Parameter(hidden = true)
             @AuthenticatedUserId
             Long actorId,
 
@@ -52,9 +53,14 @@ public class TaskController {
     }
 
     @GetMapping
-    @Operation(summary = "업무 목록 조회", description = "프로젝트 단위 업무 목록을 상태 필터와 페이지네이션 조건으로 조회합니다.")
+    @Operation(
+            summary = "업무 목록 조회",
+            description = "프로젝트 단위 업무 목록을 상태 필터와 페이지네이션 조건으로 조회합니다. "
+                    + "기본값은 page=0, size=20, sort=createdAt,desc 입니다."
+    )
     public ResponseEntity<ApiResponse<TaskPageResult<TaskSummaryResult>>> getTasks(
 
+            @Parameter(hidden = true)
             @AuthenticatedUserId
             Long actorId,
 
@@ -66,6 +72,7 @@ public class TaskController {
             @RequestParam(value = "statuses", required = false)
             List<TaskStatus> statuses,
 
+            @Parameter(description = "페이지네이션(page,size,sort). 예: page=0&size=20&sort=createdAt,desc")
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/TaskController.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/TaskController.java
@@ -1,0 +1,75 @@
+package com.example.workmanagement.domain.task.presentation;
+
+import com.example.workmanagement.domain.task.domain.model.TaskStatus;
+import com.example.workmanagement.domain.task.service.TaskQueryService;
+import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
+import com.example.workmanagement.domain.task.service.result.TaskPageResult;
+import com.example.workmanagement.domain.task.service.result.TaskSummaryResult;
+import com.example.workmanagement.global.response.ApiResponse;
+import com.example.workmanagement.global.security.resolver.AuthenticatedUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/projects/{projectId}/tasks")
+@Tag(name = "업무", description = "업무 조회 API")
+public class TaskController {
+
+    private final TaskQueryService taskQueryService;
+
+    public TaskController(TaskQueryService taskQueryService) {
+        this.taskQueryService = taskQueryService;
+    }
+
+    @GetMapping("/{taskId}")
+    @Operation(summary = "업무 상세 조회", description = "특정 프로젝트의 업무 상세 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> getTask(
+
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId
+    ) {
+        TaskDetailResult result = taskQueryService.findTask(projectId, taskId, actorId);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping
+    @Operation(summary = "업무 목록 조회", description = "프로젝트 단위 업무 목록을 상태 필터와 페이지네이션 조건으로 조회합니다.")
+    public ResponseEntity<ApiResponse<TaskPageResult<TaskSummaryResult>>> getTasks(
+
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "상태 필터(복수 가능)", example = "PENDING,IN_PROGRESS")
+            @RequestParam(value = "statuses", required = false)
+            List<TaskStatus> statuses,
+
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        TaskPageResult<TaskSummaryResult> result = taskQueryService.findTasks(projectId, actorId, statuses, pageable);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/example/workmanagement/domain/task/repository/TaskRepository.java
@@ -1,0 +1,16 @@
+package com.example.workmanagement.domain.task.repository;
+
+import com.example.workmanagement.domain.task.domain.model.Task;
+import com.example.workmanagement.domain.task.domain.model.TaskStatus;
+import java.util.Collection;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    Page<Task> findAllByProjectId(Long projectId, Pageable pageable);
+
+    Page<Task> findAllByProjectIdAndStatusIn(Long projectId, Collection<TaskStatus> statuses, Pageable pageable);
+}

--- a/src/main/java/com/example/workmanagement/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/example/workmanagement/domain/task/repository/TaskRepository.java
@@ -3,7 +3,6 @@ package com.example.workmanagement.domain.task.repository;
 import com.example.workmanagement.domain.task.domain.model.Task;
 import com.example.workmanagement.domain.task.domain.model.TaskStatus;
 import java.util.Collection;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/workmanagement/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/example/workmanagement/domain/task/repository/TaskRepository.java
@@ -2,14 +2,75 @@ package com.example.workmanagement.domain.task.repository;
 
 import com.example.workmanagement.domain.task.domain.model.Task;
 import com.example.workmanagement.domain.task.domain.model.TaskStatus;
+import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
+import com.example.workmanagement.domain.task.service.result.TaskSummaryResult;
 import java.util.Collection;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
 
-    Page<Task> findAllByProjectId(Long projectId, Pageable pageable);
+    @Query("""
+            select new com.example.workmanagement.domain.task.service.result.TaskDetailResult(
+                t.id,
+                t.projectId,
+                t.authorId,
+                t.title,
+                t.description,
+                t.status,
+                t.priority,
+                t.startDate,
+                t.dueDate,
+                t.createdAt,
+                t.updatedAt
+            )
+            from Task t
+            where t.id = :taskId
+            """)
+    Optional<TaskDetailResult> findDetailById(@Param("taskId") Long taskId);
 
-    Page<Task> findAllByProjectIdAndStatusIn(Long projectId, Collection<TaskStatus> statuses, Pageable pageable);
+    @Query("""
+            select new com.example.workmanagement.domain.task.service.result.TaskSummaryResult(
+                t.id,
+                t.projectId,
+                t.title,
+                t.status,
+                t.priority,
+                t.startDate,
+                t.dueDate,
+                t.authorId,
+                t.createdAt,
+                t.updatedAt
+            )
+            from Task t
+            where t.projectId = :projectId
+            """)
+    Page<TaskSummaryResult> findSummaryByProjectId(@Param("projectId") Long projectId, Pageable pageable);
+
+    @Query("""
+            select new com.example.workmanagement.domain.task.service.result.TaskSummaryResult(
+                t.id,
+                t.projectId,
+                t.title,
+                t.status,
+                t.priority,
+                t.startDate,
+                t.dueDate,
+                t.authorId,
+                t.createdAt,
+                t.updatedAt
+            )
+            from Task t
+            where t.projectId = :projectId
+              and t.status in :statuses
+            """)
+    Page<TaskSummaryResult> findSummaryByProjectIdAndStatusIn(
+            @Param("projectId") Long projectId,
+            @Param("statuses") Collection<TaskStatus> statuses,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/example/workmanagement/domain/task/service/TaskQueryService.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/TaskQueryService.java
@@ -2,15 +2,17 @@ package com.example.workmanagement.domain.task.service;
 
 import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
 import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
-import com.example.workmanagement.domain.task.domain.model.Task;
 import com.example.workmanagement.domain.task.domain.model.TaskStatus;
 import com.example.workmanagement.domain.task.error.TaskErrorCode;
 import com.example.workmanagement.domain.task.exception.TaskDomainException;
 import com.example.workmanagement.domain.task.repository.TaskRepository;
+import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
+import com.example.workmanagement.domain.task.service.result.TaskPageResult;
+import com.example.workmanagement.domain.task.service.result.TaskSummaryResult;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 public class TaskQueryService {
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int MAX_PAGE_SIZE = 100;
 
     private final TaskRepository taskRepository;
     private final ProjectMemberRepository projectMemberRepository;
@@ -27,7 +32,7 @@ public class TaskQueryService {
         this.projectMemberRepository = projectMemberRepository;
     }
 
-    public Task findTask(Long projectId, Long taskId, Long actorId) {
+    public TaskDetailResult findTask(Long projectId, Long taskId, Long actorId) {
 
         validatePositiveId(projectId, "projectId");
         validatePositiveId(taskId, "taskId");
@@ -35,28 +40,36 @@ public class TaskQueryService {
 
         ensureProjectMembership(projectId, actorId);
 
-        if (!taskRepository.existsByIdAndProjectId(taskId, projectId)) {
+        TaskDetailResult detailResult = taskRepository.findDetailById(taskId)
+                .orElseThrow(() -> new TaskDomainException(TaskErrorCode.TASK_NOT_FOUND));
+
+        if (!Objects.equals(detailResult.projectId(), projectId)) {
             throw new TaskDomainException(TaskErrorCode.TASK_NOT_FOUND);
         }
 
-        Task task = taskRepository.findById(taskId)
-                .orElseThrow(() -> new TaskDomainException(TaskErrorCode.TASK_NOT_FOUND));
-
-        return task;
+        return detailResult;
     }
 
-    public Page<Task> findTasks(Long projectId, Long actorId, Collection<TaskStatus> statuses, Pageable pageable) {
+    public TaskPageResult<TaskSummaryResult> findTasks(
+            Long projectId,
+            Long actorId,
+            Collection<TaskStatus> statuses,
+            Pageable pageable
+    ) {
 
         validatePositiveId(projectId, "projectId");
         validatePositiveId(actorId, "actorId");
 
         ensureProjectMembership(projectId, actorId);
 
+        Pageable safePageable = sanitizePageable(pageable);
         List<TaskStatus> normalizedStatuses = normalizeStatuses(statuses);
-        if (normalizedStatuses.isEmpty()) {
-            return taskRepository.findAllByProjectId(projectId, pageable);
-        }
-        return taskRepository.findAllByProjectIdAndStatusIn(projectId, normalizedStatuses, pageable);
+
+        var summaryPage = normalizedStatuses.isEmpty()
+                ? taskRepository.findSummaryByProjectId(projectId, safePageable)
+                : taskRepository.findSummaryByProjectIdAndStatusIn(projectId, normalizedStatuses, safePageable);
+
+        return TaskPageResult.from(summaryPage);
     }
 
     // ----- helpers
@@ -83,6 +96,17 @@ public class TaskQueryService {
         }
 
         return statuses.stream().distinct().toList();
+    }
+
+    private static Pageable sanitizePageable(Pageable pageable) {
+        Pageable resolved = pageable == null
+                ? PageRequest.of(0, DEFAULT_PAGE_SIZE)
+                : pageable;
+
+        int safePage = Math.max(resolved.getPageNumber(), 0);
+        int requestedSize = resolved.getPageSize() <= 0 ? DEFAULT_PAGE_SIZE : resolved.getPageSize();
+        int safeSize = Math.min(requestedSize, MAX_PAGE_SIZE);
+        return PageRequest.of(safePage, safeSize, resolved.getSort());
     }
 
     private static void validatePositiveId(Long id, String fieldName) {

--- a/src/main/java/com/example/workmanagement/domain/task/service/TaskQueryService.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/TaskQueryService.java
@@ -1,0 +1,94 @@
+package com.example.workmanagement.domain.task.service;
+
+import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
+import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
+import com.example.workmanagement.domain.task.domain.model.Task;
+import com.example.workmanagement.domain.task.domain.model.TaskStatus;
+import com.example.workmanagement.domain.task.error.TaskErrorCode;
+import com.example.workmanagement.domain.task.exception.TaskDomainException;
+import com.example.workmanagement.domain.task.repository.TaskRepository;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class TaskQueryService {
+
+    private final TaskRepository taskRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+
+    public TaskQueryService(TaskRepository taskRepository, ProjectMemberRepository projectMemberRepository) {
+        this.taskRepository = taskRepository;
+        this.projectMemberRepository = projectMemberRepository;
+    }
+
+    public Task findTask(Long projectId, Long taskId, Long actorId) {
+
+        validatePositiveId(projectId, "projectId");
+        validatePositiveId(taskId, "taskId");
+        validatePositiveId(actorId, "actorId");
+
+        ensureProjectMembership(projectId, actorId);
+
+        if (!taskRepository.existsByIdAndProjectId(taskId, projectId)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_NOT_FOUND);
+        }
+
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new TaskDomainException(TaskErrorCode.TASK_NOT_FOUND));
+
+        return task;
+    }
+
+    public Page<Task> findTasks(Long projectId, Long actorId, Collection<TaskStatus> statuses, Pageable pageable) {
+
+        validatePositiveId(projectId, "projectId");
+        validatePositiveId(actorId, "actorId");
+
+        ensureProjectMembership(projectId, actorId);
+
+        List<TaskStatus> normalizedStatuses = normalizeStatuses(statuses);
+        if (normalizedStatuses.isEmpty()) {
+            return taskRepository.findAllByProjectId(projectId, pageable);
+        }
+        return taskRepository.findAllByProjectIdAndStatusIn(projectId, normalizedStatuses, pageable);
+    }
+
+    // ----- helpers
+
+    private void ensureProjectMembership(Long projectId, Long actorId) {
+
+        boolean activeMember = projectMemberRepository
+                .findByProjectIdAndUserIdAndStatus(projectId, actorId, ProjectMemberStatus.ACTIVE)
+                .isPresent();
+
+        if (!activeMember) {
+            throw new TaskDomainException(TaskErrorCode.TASK_PROJECT_MEMBERSHIP_REQUIRED);
+        }
+    }
+
+    private static List<TaskStatus> normalizeStatuses(Collection<TaskStatus> statuses) {
+
+        if (statuses == null || statuses.isEmpty()) {
+            return List.of();
+        }
+
+        if (statuses.stream().anyMatch(Objects::isNull)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_STATUS_INVALID);
+        }
+
+        return statuses.stream().distinct().toList();
+    }
+
+    private static void validatePositiveId(Long id, String fieldName) {
+
+        if (id == null || id <= 0L) {
+            throw new TaskDomainException(TaskErrorCode.TASK_INVALID_ARGUMENT, fieldName + " must be positive");
+        }
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/TaskQueryService.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/TaskQueryService.java
@@ -9,11 +9,14 @@ import com.example.workmanagement.domain.task.repository.TaskRepository;
 import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
 import com.example.workmanagement.domain.task.service.result.TaskPageResult;
 import com.example.workmanagement.domain.task.service.result.TaskSummaryResult;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +26,19 @@ public class TaskQueryService {
 
     private static final int DEFAULT_PAGE_SIZE = 20;
     private static final int MAX_PAGE_SIZE = 100;
+    private static final Set<String> ALLOWED_SORT_PROPERTIES = Set.of(
+            "id",
+            "createdAt",
+            "updatedAt",
+            "startDate",
+            "dueDate",
+            "priority",
+            "status"
+    );
+    private static final Sort DEFAULT_SORT = Sort.by(
+            Sort.Order.desc("createdAt"),
+            Sort.Order.desc("id")
+    );
 
     private final TaskRepository taskRepository;
     private final ProjectMemberRepository projectMemberRepository;
@@ -100,13 +116,41 @@ public class TaskQueryService {
 
     private static Pageable sanitizePageable(Pageable pageable) {
         Pageable resolved = pageable == null
-                ? PageRequest.of(0, DEFAULT_PAGE_SIZE)
+                ? PageRequest.of(0, DEFAULT_PAGE_SIZE, DEFAULT_SORT)
                 : pageable;
 
         int safePage = Math.max(resolved.getPageNumber(), 0);
         int requestedSize = resolved.getPageSize() <= 0 ? DEFAULT_PAGE_SIZE : resolved.getPageSize();
         int safeSize = Math.min(requestedSize, MAX_PAGE_SIZE);
-        return PageRequest.of(safePage, safeSize, resolved.getSort());
+        Sort safeSort = sanitizeSort(resolved.getSort());
+
+        return PageRequest.of(safePage, safeSize, safeSort);
+    }
+
+    private static Sort sanitizeSort(Sort requestedSort) {
+        if (requestedSort == null || requestedSort.isUnsorted()) {
+            return DEFAULT_SORT;
+        }
+
+        List<Sort.Order> allowedOrders = new ArrayList<>();
+        for (Sort.Order order : requestedSort) {
+            if (ALLOWED_SORT_PROPERTIES.contains(order.getProperty())) {
+                allowedOrders.add(order);
+            }
+        }
+
+        if (allowedOrders.isEmpty()) {
+            return DEFAULT_SORT;
+        }
+
+        boolean hasIdOrder = allowedOrders.stream()
+                .anyMatch(order -> "id".equals(order.getProperty()));
+
+        if (!hasIdOrder) {
+            allowedOrders.add(Sort.Order.desc("id"));
+        }
+
+        return Sort.by(allowedOrders);
     }
 
     private static void validatePositiveId(Long id, String fieldName) {

--- a/src/main/java/com/example/workmanagement/domain/task/service/result/TaskDetailResult.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/result/TaskDetailResult.java
@@ -1,0 +1,34 @@
+package com.example.workmanagement.domain.task.service.result;
+
+import com.example.workmanagement.domain.task.domain.model.TaskPriority;
+import com.example.workmanagement.domain.task.domain.model.TaskStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Schema(description = "업무 상세 응답")
+public record TaskDetailResult(
+        @Schema(description = "업무 ID", example = "100")
+        Long taskId,
+        @Schema(description = "프로젝트 ID", example = "10")
+        Long projectId,
+        @Schema(description = "작성자 사용자 ID", example = "101")
+        Long authorId,
+        @Schema(description = "업무 제목", example = "백엔드 API 설계")
+        String title,
+        @Schema(description = "업무 설명")
+        String description,
+        @Schema(description = "업무 상태", example = "IN_PROGRESS")
+        TaskStatus status,
+        @Schema(description = "업무 우선순위", example = "HIGH")
+        TaskPriority priority,
+        @Schema(description = "시작일", example = "2026-03-17")
+        LocalDate startDate,
+        @Schema(description = "마감일", example = "2026-03-20")
+        LocalDate dueDate,
+        @Schema(description = "생성 시각", example = "2026-03-17T05:00:00Z")
+        Instant createdAt,
+        @Schema(description = "수정 시각", example = "2026-03-17T06:00:00Z")
+        Instant updatedAt
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/result/TaskPageResult.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/result/TaskPageResult.java
@@ -1,0 +1,35 @@
+package com.example.workmanagement.domain.task.service.result;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+@Schema(description = "업무 목록 페이지 응답")
+public record TaskPageResult<T>(
+        @Schema(description = "현재 페이지 데이터")
+        List<T> items,
+        @Schema(description = "현재 페이지 번호(0-base)", example = "0")
+        int page,
+        @Schema(description = "페이지 크기", example = "20")
+        int size,
+        @Schema(description = "전체 데이터 건수", example = "135")
+        long totalElements,
+        @Schema(description = "전체 페이지 수", example = "7")
+        int totalPages,
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext,
+        @Schema(description = "이전 페이지 존재 여부", example = "false")
+        boolean hasPrevious
+) {
+    public static <T> TaskPageResult<T> from(Page<T> page) {
+        return new TaskPageResult<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.hasNext(),
+                page.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/result/TaskSummaryResult.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/result/TaskSummaryResult.java
@@ -1,0 +1,32 @@
+package com.example.workmanagement.domain.task.service.result;
+
+import com.example.workmanagement.domain.task.domain.model.TaskPriority;
+import com.example.workmanagement.domain.task.domain.model.TaskStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Schema(description = "업무 목록 요약 응답")
+public record TaskSummaryResult(
+        @Schema(description = "업무 ID", example = "100")
+        Long taskId,
+        @Schema(description = "프로젝트 ID", example = "10")
+        Long projectId,
+        @Schema(description = "업무 제목", example = "백엔드 API 설계")
+        String title,
+        @Schema(description = "업무 상태", example = "IN_PROGRESS")
+        TaskStatus status,
+        @Schema(description = "업무 우선순위", example = "HIGH")
+        TaskPriority priority,
+        @Schema(description = "시작일", example = "2026-03-17")
+        LocalDate startDate,
+        @Schema(description = "마감일", example = "2026-03-20")
+        LocalDate dueDate,
+        @Schema(description = "작성자 사용자 ID", example = "101")
+        Long authorId,
+        @Schema(description = "생성 시각", example = "2026-03-17T05:00:00Z")
+        Instant createdAt,
+        @Schema(description = "수정 시각", example = "2026-03-17T06:00:00Z")
+        Instant updatedAt
+) {
+}

--- a/src/test/java/com/example/workmanagement/domain/task/presentation/TaskControllerTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/presentation/TaskControllerTest.java
@@ -1,0 +1,188 @@
+package com.example.workmanagement.domain.task.presentation;
+
+import com.example.workmanagement.domain.task.domain.model.TaskPriority;
+import com.example.workmanagement.domain.task.domain.model.TaskStatus;
+import com.example.workmanagement.domain.task.service.TaskQueryService;
+import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
+import com.example.workmanagement.domain.task.service.result.TaskPageResult;
+import com.example.workmanagement.domain.task.service.result.TaskSummaryResult;
+import com.example.workmanagement.global.error.GlobalExceptionHandler;
+import com.example.workmanagement.global.security.resolver.AuthenticatedUserIdArgumentResolver;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class TaskControllerTest {
+
+    @Mock
+    private TaskQueryService taskQueryService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        TaskController controller = new TaskController(taskQueryService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(
+                        new AuthenticatedUserIdArgumentResolver(),
+                        new PageableHandlerMethodArgumentResolver()
+                )
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getTask_shouldResolveActorAndReturnDetail() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L);
+
+        when(taskQueryService.findTask(10L, 100L, 101L)).thenReturn(detailResult);
+
+        mockMvc.perform(get("/api/v1/projects/{projectId}/tasks/{taskId}", 10L, 100L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.taskId").value(100))
+                .andExpect(jsonPath("$.data.projectId").value(10))
+                .andExpect(jsonPath("$.errorInfo").doesNotExist());
+
+        verify(taskQueryService).findTask(10L, 100L, 101L);
+    }
+
+    @Test
+    void getTasks_withoutParams_shouldApplyPageableDefault() throws Exception {
+        authenticateAs(101L);
+        TaskPageResult<TaskSummaryResult> pageResult = new TaskPageResult<>(
+                List.of(createTaskSummary(100L, 10L)),
+                0,
+                20,
+                1,
+                1,
+                false,
+                false
+        );
+
+        when(taskQueryService.findTasks(eq(10L), eq(101L), isNull(), any(Pageable.class))).thenReturn(pageResult);
+
+        mockMvc.perform(get("/api/v1/projects/{projectId}/tasks", 10L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.size").value(20))
+                .andExpect(jsonPath("$.data.items[0].taskId").value(100));
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(taskQueryService).findTasks(eq(10L), eq(101L), isNull(), pageableCaptor.capture());
+        assertEquals(0, pageableCaptor.getValue().getPageNumber());
+        assertEquals(20, pageableCaptor.getValue().getPageSize());
+        assertEquals("createdAt: DESC", pageableCaptor.getValue().getSort().toString());
+    }
+
+    @Test
+    void getTasks_withStatusesAndPagingParams_shouldBindRequestValues() throws Exception {
+        authenticateAs(101L);
+        List<TaskStatus> statuses = List.of(TaskStatus.PENDING, TaskStatus.IN_PROGRESS);
+        TaskPageResult<TaskSummaryResult> pageResult = new TaskPageResult<>(
+                List.of(createTaskSummary(100L, 10L)),
+                1,
+                30,
+                1,
+                1,
+                false,
+                true
+        );
+
+        when(taskQueryService.findTasks(eq(10L), eq(101L), eq(statuses), any(Pageable.class))).thenReturn(pageResult);
+
+        mockMvc.perform(get("/api/v1/projects/{projectId}/tasks", 10L)
+                        .param("statuses", "PENDING", "IN_PROGRESS")
+                        .param("page", "1")
+                        .param("size", "30")
+                        .param("sort", "dueDate,asc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.page").value(1))
+                .andExpect(jsonPath("$.data.size").value(30));
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(taskQueryService).findTasks(eq(10L), eq(101L), eq(statuses), pageableCaptor.capture());
+        assertEquals(1, pageableCaptor.getValue().getPageNumber());
+        assertEquals(30, pageableCaptor.getValue().getPageSize());
+        assertEquals("dueDate: ASC", pageableCaptor.getValue().getSort().toString());
+    }
+
+    @Test
+    void getTask_whenUnauthenticated_shouldReturnUnauthorized() throws Exception {
+        SecurityContextHolder.clearContext();
+
+        mockMvc.perform(get("/api/v1/projects/{projectId}/tasks/{taskId}", 10L, 100L))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorInfo.code").value("USER_UNAUTHENTICATED"));
+
+        verifyNoInteractions(taskQueryService);
+    }
+
+    private void authenticateAs(Long userId) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(userId.toString(), "N/A", List.of()));
+        SecurityContextHolder.setContext(context);
+    }
+
+    private TaskDetailResult createTaskDetail(Long taskId, Long projectId) {
+        return new TaskDetailResult(
+                taskId,
+                projectId,
+                101L,
+                "업무 제목",
+                "업무 설명",
+                TaskStatus.IN_PROGRESS,
+                TaskPriority.HIGH,
+                LocalDate.of(2026, 3, 17),
+                LocalDate.of(2026, 3, 20),
+                Instant.parse("2026-03-17T05:00:00Z"),
+                Instant.parse("2026-03-17T06:00:00Z")
+        );
+    }
+
+    private TaskSummaryResult createTaskSummary(Long taskId, Long projectId) {
+        return new TaskSummaryResult(
+                taskId,
+                projectId,
+                "업무 제목",
+                TaskStatus.IN_PROGRESS,
+                TaskPriority.HIGH,
+                LocalDate.of(2026, 3, 17),
+                LocalDate.of(2026, 3, 20),
+                101L,
+                Instant.parse("2026-03-17T05:00:00Z"),
+                Instant.parse("2026-03-17T06:00:00Z")
+        );
+    }
+}

--- a/src/test/java/com/example/workmanagement/domain/task/repository/TaskRepositoryDataJpaTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/repository/TaskRepositoryDataJpaTest.java
@@ -1,0 +1,93 @@
+package com.example.workmanagement.domain.task.repository;
+
+import com.example.workmanagement.domain.task.domain.model.Task;
+import com.example.workmanagement.domain.task.domain.model.TaskPriority;
+import com.example.workmanagement.domain.task.domain.model.TaskStatus;
+import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
+import com.example.workmanagement.domain.task.service.result.TaskSummaryResult;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+class TaskRepositoryDataJpaTest {
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @BeforeEach
+    void setUp() {
+        taskRepository.deleteAll();
+    }
+
+    @Test
+    void findDetailById_shouldReturnProjectedDetail() {
+        taskRepository.save(Task.createNew(
+                10L,
+                101L,
+                "업무 제목",
+                "업무 설명",
+                LocalDate.of(2026, 3, 17),
+                LocalDate.of(2026, 3, 20),
+                TaskPriority.HIGH
+        ));
+
+        Long taskId = taskRepository.findSummaryByProjectId(10L, PageRequest.of(0, 1))
+                .getContent()
+                .getFirst()
+                .taskId();
+
+        TaskDetailResult detail = taskRepository.findDetailById(taskId).orElseThrow();
+
+        assertEquals(taskId, detail.taskId());
+        assertEquals(10L, detail.projectId());
+        assertEquals(101L, detail.authorId());
+        assertEquals("업무 제목", detail.title());
+        assertEquals("업무 설명", detail.description());
+        assertEquals(TaskStatus.PENDING, detail.status());
+        assertEquals(TaskPriority.HIGH, detail.priority());
+    }
+
+    @Test
+    void findSummaryByProjectId_shouldReturnOnlyProjectTasks() {
+        taskRepository.save(Task.createNew(10L, 101L, "업무 A", null, null, null, TaskPriority.HIGH));
+        taskRepository.save(Task.createNew(10L, 102L, "업무 B", null, null, null, TaskPriority.MEDIUM));
+        taskRepository.save(Task.createNew(20L, 103L, "업무 C", null, null, null, TaskPriority.LOW));
+
+        Page<TaskSummaryResult> page = taskRepository.findSummaryByProjectId(10L, PageRequest.of(0, 10));
+
+        assertEquals(2, page.getTotalElements());
+        assertTrue(page.getContent().stream().allMatch(summary -> summary.projectId().equals(10L)));
+    }
+
+    @Test
+    void findSummaryByProjectIdAndStatusIn_shouldFilterByStatusAndProject() {
+        taskRepository.save(Task.createNew(10L, 101L, "업무 A", null, null, null, TaskPriority.HIGH));
+        taskRepository.save(Task.createNew(10L, 102L, "업무 B", null, null, null, TaskPriority.MEDIUM));
+        taskRepository.save(Task.createNew(20L, 103L, "업무 C", null, null, null, TaskPriority.LOW));
+
+        Page<TaskSummaryResult> pendingPage = taskRepository.findSummaryByProjectIdAndStatusIn(
+                10L,
+                List.of(TaskStatus.PENDING),
+                PageRequest.of(0, 10)
+        );
+
+        Page<TaskSummaryResult> inReviewPage = taskRepository.findSummaryByProjectIdAndStatusIn(
+                10L,
+                List.of(TaskStatus.IN_REVIEW),
+                PageRequest.of(0, 10)
+        );
+
+        assertEquals(2, pendingPage.getTotalElements());
+        assertTrue(pendingPage.getContent().stream().allMatch(summary -> summary.projectId().equals(10L)));
+        assertEquals(0, inReviewPage.getTotalElements());
+    }
+}

--- a/src/test/java/com/example/workmanagement/domain/task/service/TaskQueryServiceTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/service/TaskQueryServiceTest.java
@@ -1,0 +1,142 @@
+package com.example.workmanagement.domain.task.service;
+
+import com.example.workmanagement.domain.project.entity.ProjectMember;
+import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
+import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
+import com.example.workmanagement.domain.task.domain.model.Task;
+import com.example.workmanagement.domain.task.domain.model.TaskStatus;
+import com.example.workmanagement.domain.task.error.TaskErrorCode;
+import com.example.workmanagement.domain.task.exception.TaskDomainException;
+import com.example.workmanagement.domain.task.repository.TaskRepository;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TaskQueryServiceTest {
+
+    private final TaskRepository taskRepository = Mockito.mock(TaskRepository.class);
+    private final ProjectMemberRepository projectMemberRepository = Mockito.mock(ProjectMemberRepository.class);
+    private final TaskQueryService taskQueryService = new TaskQueryService(taskRepository, projectMemberRepository);
+
+    @Test
+    void findTask_whenNotProjectMember_shouldThrowForbidden() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskQueryService.findTask(1L, 100L, 10L)
+        );
+
+        assertEquals(TaskErrorCode.TASK_PROJECT_MEMBERSHIP_REQUIRED, exception.errorCode());
+        verify(taskRepository, never()).existsByIdAndProjectId(anyLong(), anyLong());
+        verify(taskRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    void findTask_whenProjectScopeMismatched_shouldThrowNotFound() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.existsByIdAndProjectId(100L, 1L)).thenReturn(false);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskQueryService.findTask(1L, 100L, 10L)
+        );
+
+        assertEquals(TaskErrorCode.TASK_NOT_FOUND, exception.errorCode());
+        verify(taskRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    void findTask_whenTaskMissing_shouldThrowNotFound() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.existsByIdAndProjectId(100L, 1L)).thenReturn(true);
+        when(taskRepository.findById(100L)).thenReturn(Optional.empty());
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskQueryService.findTask(1L, 100L, 10L)
+        );
+
+        assertEquals(TaskErrorCode.TASK_NOT_FOUND, exception.errorCode());
+    }
+
+    @Test
+    void findTask_whenValid_shouldReturnTask() {
+        Task task = Mockito.mock(Task.class);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.existsByIdAndProjectId(100L, 1L)).thenReturn(true);
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+
+        Task result = taskQueryService.findTask(1L, 100L, 10L);
+
+        assertSame(task, result);
+    }
+
+    @Test
+    void findTasks_withoutStatuses_shouldUseProjectOnlyQuery() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Task> page = new PageImpl<>(List.of(Mockito.mock(Task.class)), pageable, 1);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findAllByProjectId(1L, pageable)).thenReturn(page);
+
+        Page<Task> result = taskQueryService.findTasks(1L, 10L, null, pageable);
+
+        assertSame(page, result);
+        verify(taskRepository).findAllByProjectId(1L, pageable);
+        verify(taskRepository, never()).findAllByProjectIdAndStatusIn(anyLong(), any(), any(Pageable.class));
+    }
+
+    @Test
+    void findTasks_withStatuses_shouldUseStatusFilterQuery() {
+        Pageable pageable = PageRequest.of(0, 20);
+        List<TaskStatus> statuses = List.of(TaskStatus.PENDING, TaskStatus.IN_PROGRESS);
+        Page<Task> page = new PageImpl<>(List.of(Mockito.mock(Task.class)), pageable, 1);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findAllByProjectIdAndStatusIn(1L, statuses, pageable)).thenReturn(page);
+
+        Page<Task> result = taskQueryService.findTasks(1L, 10L, statuses, pageable);
+
+        assertSame(page, result);
+        verify(taskRepository).findAllByProjectIdAndStatusIn(1L, statuses, pageable);
+    }
+
+    @Test
+    void findTasks_withNullStatusItem_shouldThrowBadRequest() {
+        Pageable pageable = PageRequest.of(0, 20);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskQueryService.findTasks(1L, 10L, Arrays.asList(TaskStatus.PENDING, null), pageable)
+        );
+
+        assertEquals(TaskErrorCode.TASK_STATUS_INVALID, exception.errorCode());
+        verify(taskRepository, never()).findAllByProjectIdAndStatusIn(anyLong(), any(), any(Pageable.class));
+    }
+}

--- a/src/test/java/com/example/workmanagement/domain/task/service/TaskQueryServiceTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/service/TaskQueryServiceTest.java
@@ -3,15 +3,21 @@ package com.example.workmanagement.domain.task.service;
 import com.example.workmanagement.domain.project.entity.ProjectMember;
 import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
 import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
-import com.example.workmanagement.domain.task.domain.model.Task;
+import com.example.workmanagement.domain.task.domain.model.TaskPriority;
 import com.example.workmanagement.domain.task.domain.model.TaskStatus;
 import com.example.workmanagement.domain.task.error.TaskErrorCode;
 import com.example.workmanagement.domain.task.exception.TaskDomainException;
 import com.example.workmanagement.domain.task.repository.TaskRepository;
+import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
+import com.example.workmanagement.domain.task.service.result.TaskPageResult;
+import com.example.workmanagement.domain.task.service.result.TaskSummaryResult;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -23,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,31 +51,14 @@ class TaskQueryServiceTest {
         );
 
         assertEquals(TaskErrorCode.TASK_PROJECT_MEMBERSHIP_REQUIRED, exception.errorCode());
-        verify(taskRepository, never()).existsByIdAndProjectId(anyLong(), anyLong());
-        verify(taskRepository, never()).findById(anyLong());
-    }
-
-    @Test
-    void findTask_whenProjectScopeMismatched_shouldThrowNotFound() {
-        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
-                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
-        when(taskRepository.existsByIdAndProjectId(100L, 1L)).thenReturn(false);
-
-        TaskDomainException exception = assertThrows(
-                TaskDomainException.class,
-                () -> taskQueryService.findTask(1L, 100L, 10L)
-        );
-
-        assertEquals(TaskErrorCode.TASK_NOT_FOUND, exception.errorCode());
-        verify(taskRepository, never()).findById(anyLong());
+        verify(taskRepository, never()).findDetailById(anyLong());
     }
 
     @Test
     void findTask_whenTaskMissing_shouldThrowNotFound() {
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
-        when(taskRepository.existsByIdAndProjectId(100L, 1L)).thenReturn(true);
-        when(taskRepository.findById(100L)).thenReturn(Optional.empty());
+        when(taskRepository.findDetailById(100L)).thenReturn(Optional.empty());
 
         TaskDomainException exception = assertThrows(
                 TaskDomainException.class,
@@ -79,49 +69,86 @@ class TaskQueryServiceTest {
     }
 
     @Test
-    void findTask_whenValid_shouldReturnTask() {
-        Task task = Mockito.mock(Task.class);
+    void findTask_whenProjectScopeMismatched_shouldThrowNotFound() {
+        TaskDetailResult detailResult = createTaskDetail(100L, 2L);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
-        when(taskRepository.existsByIdAndProjectId(100L, 1L)).thenReturn(true);
-        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detailResult));
 
-        Task result = taskQueryService.findTask(1L, 100L, 10L);
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskQueryService.findTask(1L, 100L, 10L)
+        );
 
-        assertSame(task, result);
+        assertEquals(TaskErrorCode.TASK_NOT_FOUND, exception.errorCode());
+    }
+
+    @Test
+    void findTask_whenValid_shouldReturnDetailResult() {
+        TaskDetailResult detailResult = createTaskDetail(100L, 1L);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detailResult));
+
+        TaskDetailResult result = taskQueryService.findTask(1L, 100L, 10L);
+
+        assertSame(detailResult, result);
     }
 
     @Test
     void findTasks_withoutStatuses_shouldUseProjectOnlyQuery() {
         Pageable pageable = PageRequest.of(0, 20);
-        Page<Task> page = new PageImpl<>(List.of(Mockito.mock(Task.class)), pageable, 1);
+        TaskSummaryResult summary = createTaskSummary(100L, 1L);
+        Page<TaskSummaryResult> page = new PageImpl<>(List.of(summary), pageable, 1);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
-        when(taskRepository.findAllByProjectId(1L, pageable)).thenReturn(page);
+        when(taskRepository.findSummaryByProjectId(1L, pageable)).thenReturn(page);
 
-        Page<Task> result = taskQueryService.findTasks(1L, 10L, null, pageable);
+        TaskPageResult<TaskSummaryResult> result = taskQueryService.findTasks(1L, 10L, null, pageable);
 
-        assertSame(page, result);
-        verify(taskRepository).findAllByProjectId(1L, pageable);
-        verify(taskRepository, never()).findAllByProjectIdAndStatusIn(anyLong(), any(), any(Pageable.class));
+        assertEquals(1, result.items().size());
+        assertEquals(1, result.totalElements());
+        assertEquals(summary.taskId(), result.items().getFirst().taskId());
+        verify(taskRepository).findSummaryByProjectId(1L, pageable);
+        verify(taskRepository, never()).findSummaryByProjectIdAndStatusIn(anyLong(), any(), any(Pageable.class));
     }
 
     @Test
     void findTasks_withStatuses_shouldUseStatusFilterQuery() {
         Pageable pageable = PageRequest.of(0, 20);
         List<TaskStatus> statuses = List.of(TaskStatus.PENDING, TaskStatus.IN_PROGRESS);
-        Page<Task> page = new PageImpl<>(List.of(Mockito.mock(Task.class)), pageable, 1);
+        TaskSummaryResult summary = createTaskSummary(100L, 1L);
+        Page<TaskSummaryResult> page = new PageImpl<>(List.of(summary), pageable, 1);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
-        when(taskRepository.findAllByProjectIdAndStatusIn(1L, statuses, pageable)).thenReturn(page);
+        when(taskRepository.findSummaryByProjectIdAndStatusIn(1L, statuses, pageable)).thenReturn(page);
 
-        Page<Task> result = taskQueryService.findTasks(1L, 10L, statuses, pageable);
+        TaskPageResult<TaskSummaryResult> result = taskQueryService.findTasks(1L, 10L, statuses, pageable);
 
-        assertSame(page, result);
-        verify(taskRepository).findAllByProjectIdAndStatusIn(1L, statuses, pageable);
+        assertEquals(1, result.items().size());
+        assertEquals(summary.taskId(), result.items().getFirst().taskId());
+        verify(taskRepository).findSummaryByProjectIdAndStatusIn(1L, statuses, pageable);
+    }
+
+    @Test
+    void findTasks_whenRequestedSizeTooLarge_shouldClampToMax() {
+        Pageable requested = PageRequest.of(0, 1000);
+        Pageable clamped = PageRequest.of(0, 1000, requested.getSort());
+        Page<TaskSummaryResult> page = new PageImpl<>(List.of(createTaskSummary(100L, 1L)), PageRequest.of(0, 100), 1);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findSummaryByProjectId(eq(1L), any(Pageable.class))).thenReturn(page);
+
+        taskQueryService.findTasks(1L, 10L, null, clamped);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(taskRepository).findSummaryByProjectId(eq(1L), pageableCaptor.capture());
+        assertEquals(100, pageableCaptor.getValue().getPageSize());
     }
 
     @Test
@@ -137,6 +164,38 @@ class TaskQueryServiceTest {
         );
 
         assertEquals(TaskErrorCode.TASK_STATUS_INVALID, exception.errorCode());
-        verify(taskRepository, never()).findAllByProjectIdAndStatusIn(anyLong(), any(), any(Pageable.class));
+        verify(taskRepository, never()).findSummaryByProjectIdAndStatusIn(anyLong(), any(), any(Pageable.class));
+        verify(taskRepository, never()).findSummaryByProjectId(anyLong(), any(Pageable.class));
+    }
+
+    private TaskDetailResult createTaskDetail(Long taskId, Long projectId) {
+        return new TaskDetailResult(
+                taskId,
+                projectId,
+                101L,
+                "업무 제목",
+                "업무 설명",
+                TaskStatus.IN_PROGRESS,
+                TaskPriority.HIGH,
+                LocalDate.of(2026, 3, 17),
+                LocalDate.of(2026, 3, 20),
+                Instant.parse("2026-03-17T05:00:00Z"),
+                Instant.parse("2026-03-17T06:00:00Z")
+        );
+    }
+
+    private TaskSummaryResult createTaskSummary(Long taskId, Long projectId) {
+        return new TaskSummaryResult(
+                taskId,
+                projectId,
+                "업무 제목",
+                TaskStatus.IN_PROGRESS,
+                TaskPriority.HIGH,
+                LocalDate.of(2026, 3, 17),
+                LocalDate.of(2026, 3, 20),
+                101L,
+                Instant.parse("2026-03-17T05:00:00Z"),
+                Instant.parse("2026-03-17T06:00:00Z")
+        );
     }
 }

--- a/src/test/java/com/example/workmanagement/domain/task/service/TaskQueryServiceTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/service/TaskQueryServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -105,14 +106,19 @@ class TaskQueryServiceTest {
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
-        when(taskRepository.findSummaryByProjectId(1L, pageable)).thenReturn(page);
+        when(taskRepository.findSummaryByProjectId(eq(1L), any(Pageable.class))).thenReturn(page);
 
         TaskPageResult<TaskSummaryResult> result = taskQueryService.findTasks(1L, 10L, null, pageable);
 
         assertEquals(1, result.items().size());
         assertEquals(1, result.totalElements());
         assertEquals(summary.taskId(), result.items().getFirst().taskId());
-        verify(taskRepository).findSummaryByProjectId(1L, pageable);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(taskRepository).findSummaryByProjectId(eq(1L), pageableCaptor.capture());
+        assertEquals(20, pageableCaptor.getValue().getPageSize());
+        assertEquals(Sort.Direction.DESC, pageableCaptor.getValue().getSort().getOrderFor("createdAt").getDirection());
+        assertEquals(Sort.Direction.DESC, pageableCaptor.getValue().getSort().getOrderFor("id").getDirection());
         verify(taskRepository, never()).findSummaryByProjectIdAndStatusIn(anyLong(), any(), any(Pageable.class));
     }
 
@@ -125,30 +131,68 @@ class TaskQueryServiceTest {
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
-        when(taskRepository.findSummaryByProjectIdAndStatusIn(1L, statuses, pageable)).thenReturn(page);
+        when(taskRepository.findSummaryByProjectIdAndStatusIn(eq(1L), eq(statuses), any(Pageable.class))).thenReturn(page);
 
         TaskPageResult<TaskSummaryResult> result = taskQueryService.findTasks(1L, 10L, statuses, pageable);
 
         assertEquals(1, result.items().size());
         assertEquals(summary.taskId(), result.items().getFirst().taskId());
-        verify(taskRepository).findSummaryByProjectIdAndStatusIn(1L, statuses, pageable);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(taskRepository).findSummaryByProjectIdAndStatusIn(eq(1L), eq(statuses), pageableCaptor.capture());
+        assertEquals(20, pageableCaptor.getValue().getPageSize());
+        assertEquals(Sort.Direction.DESC, pageableCaptor.getValue().getSort().getOrderFor("createdAt").getDirection());
+        assertEquals(Sort.Direction.DESC, pageableCaptor.getValue().getSort().getOrderFor("id").getDirection());
     }
 
     @Test
     void findTasks_whenRequestedSizeTooLarge_shouldClampToMax() {
         Pageable requested = PageRequest.of(0, 1000);
-        Pageable clamped = PageRequest.of(0, 1000, requested.getSort());
         Page<TaskSummaryResult> page = new PageImpl<>(List.of(createTaskSummary(100L, 1L)), PageRequest.of(0, 100), 1);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
         when(taskRepository.findSummaryByProjectId(eq(1L), any(Pageable.class))).thenReturn(page);
 
-        taskQueryService.findTasks(1L, 10L, null, clamped);
+        taskQueryService.findTasks(1L, 10L, null, requested);
 
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
         verify(taskRepository).findSummaryByProjectId(eq(1L), pageableCaptor.capture());
         assertEquals(100, pageableCaptor.getValue().getPageSize());
+    }
+
+    @Test
+    void findTasks_whenSortContainsDisallowedField_shouldFallbackToDefaultSort() {
+        Pageable requested = PageRequest.of(0, 20, Sort.by(Sort.Order.asc("unknownField")));
+        Page<TaskSummaryResult> page = new PageImpl<>(List.of(createTaskSummary(100L, 1L)), PageRequest.of(0, 20), 1);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findSummaryByProjectId(eq(1L), any(Pageable.class))).thenReturn(page);
+
+        taskQueryService.findTasks(1L, 10L, null, requested);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(taskRepository).findSummaryByProjectId(eq(1L), pageableCaptor.capture());
+        assertEquals(Sort.Direction.DESC, pageableCaptor.getValue().getSort().getOrderFor("createdAt").getDirection());
+        assertEquals(Sort.Direction.DESC, pageableCaptor.getValue().getSort().getOrderFor("id").getDirection());
+    }
+
+    @Test
+    void findTasks_whenSortAllowedWithoutId_shouldAppendIdTiebreaker() {
+        Pageable requested = PageRequest.of(0, 20, Sort.by(Sort.Order.asc("dueDate")));
+        Page<TaskSummaryResult> page = new PageImpl<>(List.of(createTaskSummary(100L, 1L)), PageRequest.of(0, 20), 1);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findSummaryByProjectId(eq(1L), any(Pageable.class))).thenReturn(page);
+
+        taskQueryService.findTasks(1L, 10L, null, requested);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(taskRepository).findSummaryByProjectId(eq(1L), pageableCaptor.capture());
+        assertEquals(Sort.Direction.ASC, pageableCaptor.getValue().getSort().getOrderFor("dueDate").getDirection());
+        assertEquals(Sort.Direction.DESC, pageableCaptor.getValue().getSort().getOrderFor("id").getDirection());
     }
 
     @Test


### PR DESCRIPTION
### 요약
- 업무 상세 조회 API 구현
- 업무 목록 조회 API 구현
  - 페이징 적용
- 스웨거 살포시 적용
- dto 는 response 대신 서비스 계층 result 를 컨트롤러에서 받아서 그대로 내려주는 식으로 타협

### 관련 이슈
- #27 