### PR TITLE
feat(project-query) : 프로젝트 멤버 조회 분리(기본/권한포함)

### DIFF
--- a/src/main/java/com/example/workmanagement/domain/project/service/ProjectMemberQueryService.java
+++ b/src/main/java/com/example/workmanagement/domain/project/service/ProjectMemberQueryService.java
@@ -3,26 +3,98 @@ package com.example.workmanagement.domain.project.service;
 import com.example.workmanagement.domain.project.entity.ProjectMember;
 import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
 import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
+import com.example.workmanagement.global.role.entity.ProjectMemberRole;
+import com.example.workmanagement.global.role.entity.Role;
+import com.example.workmanagement.global.role.repository.ProjectMemberRoleRepository;
+import com.example.workmanagement.global.role.repository.RoleRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
 public class ProjectMemberQueryService {
 
     private final ProjectMemberRepository projectMemberRepository;
+    private final ProjectMemberRoleRepository projectMemberRoleRepository;
+    private final RoleRepository roleRepository;
 
-    public ProjectMemberQueryService(ProjectMemberRepository projectMemberRepository) {
+    public ProjectMemberQueryService(
+            ProjectMemberRepository projectMemberRepository,
+            ProjectMemberRoleRepository projectMemberRoleRepository,
+            RoleRepository roleRepository
+    ) {
         this.projectMemberRepository = projectMemberRepository;
+        this.projectMemberRoleRepository = projectMemberRoleRepository;
+        this.roleRepository = roleRepository;
     }
 
-    // policy: PJM-P-05 (퇴장/방출 후 효과 정책 - ACTIVE 멤버만 조회)
+    // policy: PJM-P-05 (LEFT/REMOVED 상태는 즉시 권한이 제거되므로 조회 대상에서 제외하고 ACTIVE 멤버만 반환)
     public List<ProjectMember> findActiveMembers(Long projectId) {
         return projectMemberRepository.findByProjectId(projectId)
                 .stream()
                 .filter(member -> member.getStatus() == ProjectMemberStatus.ACTIVE)
                 .toList();
+    }
+
+    // policy: ROL-P-03(다중 Role 권한 합집합), ROL-P-04(Role 변경 즉시 반영), PJM-P-05(비활성 멤버 권한 차단)
+    public Map<ProjectMember, List<Role>> findActiveMembersWithRoles(Long projectId) {
+        List<ProjectMember> activeMembers = findActiveMembers(projectId);
+        if (activeMembers.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Role> activeProjectRoles = roleRepository.findByProjectIdAndIsActiveTrue(projectId);
+        if (activeProjectRoles.isEmpty()) {
+            return activeMembers.stream()
+                    .collect(Collectors.toMap(
+                            member -> member,
+                            member -> List.of(),
+                            (existing, replacement) -> existing,
+                            LinkedHashMap::new
+                    ));
+        }
+
+        List<ProjectMemberRole> activeRoleLinks =
+                projectMemberRoleRepository.findActiveRoleLinksByProjectId(projectId, ProjectMemberStatus.ACTIVE);
+        if (activeRoleLinks.isEmpty()) {
+            return activeMembers.stream()
+                    .collect(Collectors.toMap(
+                            member -> member,
+                            member -> List.of(),
+                            (existing, replacement) -> existing,
+                            LinkedHashMap::new
+                    ));
+        }
+
+        Map<Long, Role> activeRoleById = activeProjectRoles
+                .stream()
+                .collect(Collectors.toMap(Role::getId, role -> role));
+
+        Map<Long, List<Role>> rolesByMemberId = new HashMap<>();
+        for (ProjectMemberRole activeRoleLink : activeRoleLinks) {
+            Role activeRole = activeRoleById.get(activeRoleLink.getRoleId());
+            if (activeRole == null) {
+                continue;
+            }
+            rolesByMemberId
+                    .computeIfAbsent(activeRoleLink.getProjectMemberId(), ignored -> new ArrayList<>())
+                    .add(activeRole);
+        }
+
+        Map<ProjectMember, List<Role>> snapshotsByMember = new LinkedHashMap<>();
+        for (ProjectMember activeMember : activeMembers) {
+            snapshotsByMember.put(
+                    activeMember,
+                    List.copyOf(rolesByMemberId.getOrDefault(activeMember.getId(), List.of()))
+            );
+        }
+        return snapshotsByMember;
     }
 }

--- a/src/main/java/com/example/workmanagement/domain/project/service/ProjectMemberQueryService.java
+++ b/src/main/java/com/example/workmanagement/domain/project/service/ProjectMemberQueryService.java
@@ -1,0 +1,28 @@
+package com.example.workmanagement.domain.project.service;
+
+import com.example.workmanagement.domain.project.entity.ProjectMember;
+import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
+import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class ProjectMemberQueryService {
+
+    private final ProjectMemberRepository projectMemberRepository;
+
+    public ProjectMemberQueryService(ProjectMemberRepository projectMemberRepository) {
+        this.projectMemberRepository = projectMemberRepository;
+    }
+
+    // policy: PJM-P-05 (퇴장/방출 후 효과 정책 - ACTIVE 멤버만 조회)
+    public List<ProjectMember> findActiveMembers(Long projectId) {
+        return projectMemberRepository.findByProjectId(projectId)
+                .stream()
+                .filter(member -> member.getStatus() == ProjectMemberStatus.ACTIVE)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/project/service/ProjectMemberQueryService.java
+++ b/src/main/java/com/example/workmanagement/domain/project/service/ProjectMemberQueryService.java
@@ -3,6 +3,10 @@ package com.example.workmanagement.domain.project.service;
 import com.example.workmanagement.domain.project.entity.ProjectMember;
 import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
 import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
+import com.example.workmanagement.domain.project.service.result.ProjectMemberBasicResult;
+import com.example.workmanagement.domain.project.service.result.ProjectMemberRoleResult;
+import com.example.workmanagement.domain.project.service.result.ProjectMemberRoleProjectionResult;
+import com.example.workmanagement.domain.project.service.result.ProjectMemberWithRolesResult;
 import com.example.workmanagement.global.role.entity.ProjectMemberRole;
 import com.example.workmanagement.global.role.entity.Role;
 import com.example.workmanagement.global.role.repository.ProjectMemberRoleRepository;
@@ -40,6 +44,13 @@ public class ProjectMemberQueryService {
         return projectMemberRepository.findByProjectId(projectId)
                 .stream()
                 .filter(member -> member.getStatus() == ProjectMemberStatus.ACTIVE)
+                .toList();
+    }
+
+    // policy: PJM-P-05 (비활성 멤버는 응답 DTO에서 제외)
+    public List<ProjectMemberBasicResult> findActiveMemberResults(Long projectId) {
+        return findActiveMembers(projectId).stream()
+                .map(this::toBasicResult)
                 .toList();
     }
 
@@ -96,5 +107,59 @@ public class ProjectMemberQueryService {
             );
         }
         return snapshotsByMember;
+    }
+
+    // policy: ROL-P-03(다중 Role 합집합), ROL-P-04(변경 즉시 반영), PJM-P-05(비활성 멤버 제외)
+    public List<ProjectMemberWithRolesResult> findActiveMemberWithRolesResults(Long projectId) {
+        Map<ProjectMember, List<Role>> memberRoleSnapshots = findActiveMembersWithRoles(projectId);
+        if (memberRoleSnapshots.isEmpty()) {
+            return List.of();
+        }
+
+        List<ProjectMemberRoleProjectionResult> roleProjections = memberRoleSnapshots.entrySet().stream()
+                .flatMap(entry -> entry.getValue().stream()
+                        .map(role -> toRoleProjectionResult(entry.getKey().getId(), role)))
+                .toList();
+
+        Map<Long, List<ProjectMemberRoleResult>> rolesByMemberId = roleProjections.stream()
+                .collect(Collectors.groupingBy(
+                        ProjectMemberRoleProjectionResult::projectMemberId,
+                        Collectors.mapping(this::toRoleResult, Collectors.toList())
+                ));
+
+        return memberRoleSnapshots.entrySet().stream()
+                .map(entry -> new ProjectMemberWithRolesResult(
+                        toBasicResult(entry.getKey()),
+                        List.copyOf(rolesByMemberId.getOrDefault(entry.getKey().getId(), List.of()))
+                ))
+                .toList();
+    }
+
+    private ProjectMemberBasicResult toBasicResult(ProjectMember member) {
+        return new ProjectMemberBasicResult(
+                member.getId(),
+                member.getProjectId(),
+                member.getUserId(),
+                member.getStatus()
+        );
+    }
+
+    private ProjectMemberRoleProjectionResult toRoleProjectionResult(Long projectMemberId, Role role) {
+        return new ProjectMemberRoleProjectionResult(
+                projectMemberId,
+                role.getId(),
+                role.getCode(),
+                role.getName(),
+                role.getDescription()
+        );
+    }
+
+    private ProjectMemberRoleResult toRoleResult(ProjectMemberRoleProjectionResult projection) {
+        return new ProjectMemberRoleResult(
+                projection.roleId(),
+                projection.roleCode(),
+                projection.roleName(),
+                projection.roleDescription()
+        );
     }
 }

--- a/src/main/java/com/example/workmanagement/domain/project/service/result/ProjectMemberBasicResult.java
+++ b/src/main/java/com/example/workmanagement/domain/project/service/result/ProjectMemberBasicResult.java
@@ -1,0 +1,11 @@
+package com.example.workmanagement.domain.project.service.result;
+
+import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
+
+public record ProjectMemberBasicResult(
+        Long projectMemberId,
+        Long projectId,
+        Long userId,
+        ProjectMemberStatus status
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/project/service/result/ProjectMemberRoleProjectionResult.java
+++ b/src/main/java/com/example/workmanagement/domain/project/service/result/ProjectMemberRoleProjectionResult.java
@@ -1,0 +1,10 @@
+package com.example.workmanagement.domain.project.service.result;
+
+public record ProjectMemberRoleProjectionResult(
+        Long projectMemberId,
+        Long roleId,
+        String roleCode,
+        String roleName,
+        String roleDescription
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/project/service/result/ProjectMemberRoleResult.java
+++ b/src/main/java/com/example/workmanagement/domain/project/service/result/ProjectMemberRoleResult.java
@@ -1,0 +1,9 @@
+package com.example.workmanagement.domain.project.service.result;
+
+public record ProjectMemberRoleResult(
+        Long roleId,
+        String roleCode,
+        String roleName,
+        String roleDescription
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/project/service/result/ProjectMemberWithRolesResult.java
+++ b/src/main/java/com/example/workmanagement/domain/project/service/result/ProjectMemberWithRolesResult.java
@@ -1,0 +1,9 @@
+package com.example.workmanagement.domain.project.service.result;
+
+import java.util.List;
+
+public record ProjectMemberWithRolesResult(
+        ProjectMemberBasicResult member,
+        List<ProjectMemberRoleResult> roles
+) {
+}

--- a/src/main/java/com/example/workmanagement/global/role/repository/ProjectMemberRoleRepository.java
+++ b/src/main/java/com/example/workmanagement/global/role/repository/ProjectMemberRoleRepository.java
@@ -1,7 +1,11 @@
 package com.example.workmanagement.global.role.repository;
 
+import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
 import com.example.workmanagement.global.role.entity.ProjectMemberRole;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Collection;
 import java.util.List;
 
@@ -12,4 +16,20 @@ public interface ProjectMemberRoleRepository extends JpaRepository<ProjectMember
 
     // policy: ROL-P-03 (권한 합집합 계산), PJM-P-05 (멤버별 역할 조회)
     List<ProjectMemberRole> findByProjectMemberIdInAndRevokedAtIsNull(Collection<Long> projectMemberIds);
+
+    @Query("""
+            select pmr
+            from ProjectMemberRole pmr
+            join com.example.workmanagement.domain.project.entity.ProjectMember pm on pm.id = pmr.projectMemberId
+            join com.example.workmanagement.global.role.entity.Role r on r.id = pmr.roleId
+            where pm.projectId = :projectId
+              and pm.status = :activeStatus
+              and pmr.revokedAt is null
+              and r.projectId = :projectId
+              and r.isActive = true
+            """)
+    List<ProjectMemberRole> findActiveRoleLinksByProjectId(
+            @Param("projectId") Long projectId,
+            @Param("activeStatus") ProjectMemberStatus activeStatus
+    );
 }

--- a/src/main/java/com/example/workmanagement/global/role/repository/RoleRepository.java
+++ b/src/main/java/com/example/workmanagement/global/role/repository/RoleRepository.java
@@ -13,6 +13,8 @@ public interface RoleRepository extends JpaRepository<Role, Long> {
 
     List<Role> findByProjectIdAndIsSystemTrue(Long projectId);
 
+    List<Role> findByProjectIdAndIsActiveTrue(Long projectId);
+
     // policy: ROL-P-03 (권한 합집합 계산)
     List<Role> findByIdInAndIsActiveTrue(Collection<Long> roleIds);
 }

--- a/src/test/java/com/example/workmanagement/domain/project/service/ProjectMemberQueryServiceDataJpaTest.java
+++ b/src/test/java/com/example/workmanagement/domain/project/service/ProjectMemberQueryServiceDataJpaTest.java
@@ -1,0 +1,187 @@
+package com.example.workmanagement.domain.project.service;
+
+import com.example.workmanagement.domain.project.entity.Project;
+import com.example.workmanagement.domain.project.entity.ProjectMember;
+import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
+import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
+import com.example.workmanagement.domain.project.repository.ProjectRepository;
+import com.example.workmanagement.domain.project.service.result.ProjectMemberBasicResult;
+import com.example.workmanagement.domain.project.service.result.ProjectMemberWithRolesResult;
+import com.example.workmanagement.global.config.JpaAuditingConfig;
+import com.example.workmanagement.global.role.entity.ProjectMemberRole;
+import com.example.workmanagement.global.role.entity.Role;
+import com.example.workmanagement.global.role.repository.ProjectMemberRoleRepository;
+import com.example.workmanagement.global.role.repository.RoleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DataJpaTest
+@Import({JpaAuditingConfig.class, ProjectMemberQueryService.class})
+class ProjectMemberQueryServiceDataJpaTest {
+
+    @Autowired
+    private ProjectMemberQueryService projectMemberQueryService;
+
+    @Autowired
+    private ProjectMemberRepository projectMemberRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private ProjectMemberRoleRepository projectMemberRoleRepository;
+
+    @MockitoSpyBean
+    private ProjectMemberRepository projectMemberRepositorySpy;
+
+    @MockitoSpyBean
+    private RoleRepository roleRepositorySpy;
+
+    @MockitoSpyBean
+    private ProjectMemberRoleRepository projectMemberRoleRepositorySpy;
+
+    private Long projectAId;
+    private Long projectBId;
+    private ProjectMember memberA1;
+    private ProjectMember memberA2;
+    private ProjectMember memberA3Inactive;
+    private Role roleADeveloper;
+    private Role roleAReviewer;
+    private Role roleAInactive;
+    private Role roleBExternal;
+
+    @BeforeEach
+    void setUp() {
+        projectMemberRoleRepository.deleteAll();
+        roleRepository.deleteAll();
+        projectMemberRepository.deleteAll();
+        projectRepository.deleteAll();
+
+        Project projectA = projectRepository.save(Project.builder()
+                .name("Project-A")
+                .description("A")
+                .imageUrl("a.png")
+                .build());
+        Project projectB = projectRepository.save(Project.builder()
+                .name("Project-B")
+                .description("B")
+                .imageUrl("b.png")
+                .build());
+        projectAId = projectA.getId();
+        projectBId = projectB.getId();
+
+        memberA1 = projectMemberRepository.save(ProjectMember.builder().projectId(projectAId).userId(101L).build());
+        memberA2 = projectMemberRepository.save(ProjectMember.builder().projectId(projectAId).userId(102L).build());
+        memberA3Inactive = projectMemberRepository.save(ProjectMember.builder().projectId(projectAId).userId(103L).build());
+        memberA3Inactive.FireMember();
+        memberA3Inactive = projectMemberRepository.save(memberA3Inactive);
+
+        roleADeveloper = roleRepository.save(Role.customRole(projectAId, "DEV", "Developer", "dev", 0L, 0L, 0L, false, memberA1.getId()));
+        roleAReviewer = roleRepository.save(Role.customRole(projectAId, "REVIEWER", "Reviewer", "review", 0L, 0L, 0L, false, memberA1.getId()));
+        roleAInactive = roleRepository.save(Role.customRole(projectAId, "OLD", "Old", "inactive", 0L, 0L, 0L, false, memberA1.getId()));
+        setRoleInactive(roleAInactive);
+        roleAInactive = roleRepository.save(roleAInactive);
+        roleBExternal = roleRepository.save(Role.customRole(projectBId, "EXTERNAL", "External", "other project", 0L, 0L, 0L, false, memberA1.getId()));
+
+        projectMemberRoleRepository.save(ProjectMemberRole.assign(memberA1.getId(), roleADeveloper.getId(), memberA1.getId()));
+        projectMemberRoleRepository.save(ProjectMemberRole.assign(memberA2.getId(), roleAReviewer.getId(), memberA1.getId()));
+        projectMemberRoleRepository.save(ProjectMemberRole.assign(memberA2.getId(), roleBExternal.getId(), memberA1.getId()));
+        projectMemberRoleRepository.save(ProjectMemberRole.assign(memberA1.getId(), roleAInactive.getId(), memberA1.getId()));
+
+        ProjectMemberRole revoked = projectMemberRoleRepository
+                .save(ProjectMemberRole.assign(memberA1.getId(), roleAReviewer.getId(), memberA1.getId()));
+        revoked.revoke(memberA1.getId());
+        projectMemberRoleRepository.save(revoked);
+
+        projectMemberRoleRepository.save(ProjectMemberRole.assign(memberA3Inactive.getId(), roleADeveloper.getId(), memberA1.getId()));
+    }
+
+    // policy: PJM-P-05 (비활성 멤버 제외)
+    @Test
+    void findActiveMemberResults_returnsOnlyActiveMembers() {
+        List<ProjectMemberBasicResult> results = projectMemberQueryService.findActiveMemberResults(projectAId);
+
+        assertEquals(2, results.size());
+        assertTrue(results.stream().allMatch(result -> result.status() == ProjectMemberStatus.ACTIVE));
+        List<Long> userIds = results.stream().map(ProjectMemberBasicResult::userId).toList();
+        assertTrue(userIds.containsAll(List.of(101L, 102L)));
+        assertFalse(userIds.contains(103L));
+    }
+
+    // policy: ROL-P-03, ROL-P-04, PJM-P-05
+    @Test
+    void findActiveMemberWithRolesResults_assemblesOnlyActiveSameProjectRoles() {
+        List<ProjectMemberWithRolesResult> results =
+                projectMemberQueryService.findActiveMemberWithRolesResults(projectAId);
+
+        assertEquals(2, results.size());
+
+        Map<Long, List<String>> roleCodesByMemberId = results.stream()
+                .collect(Collectors.toMap(
+                        result -> result.member().projectMemberId(),
+                        result -> result.roles().stream().map(role -> role.roleCode()).toList()
+                ));
+
+        assertEquals(List.of("DEV"), roleCodesByMemberId.get(memberA1.getId()));
+        assertEquals(List.of("REVIEWER"), roleCodesByMemberId.get(memberA2.getId()));
+        assertTrue(roleCodesByMemberId.values().stream().flatMap(List::stream).noneMatch("EXTERNAL"::equals));
+        assertTrue(roleCodesByMemberId.values().stream().flatMap(List::stream).noneMatch("OLD"::equals));
+    }
+
+    // policy: ROL-P-03, ROL-P-04, PJM-P-05
+    @Test
+    void findActiveMemberWithRolesResults_bulkRead_usesBatchQueriesWithoutPerMemberLoopQueries() {
+        for (int i = 0; i < 20; i++) {
+            ProjectMember member = projectMemberRepository
+                    .save(ProjectMember.builder().projectId(projectAId).userId(200L + i).build());
+            projectMemberRoleRepository
+                    .save(ProjectMemberRole.assign(member.getId(), roleADeveloper.getId(), memberA1.getId()));
+        }
+
+        reset(projectMemberRepositorySpy, roleRepositorySpy, projectMemberRoleRepositorySpy);
+
+        List<ProjectMemberWithRolesResult> results =
+                projectMemberQueryService.findActiveMemberWithRolesResults(projectAId);
+
+        assertEquals(22, results.size());
+        verify(projectMemberRepositorySpy, times(1)).findByProjectId(projectAId);
+        verify(roleRepositorySpy, times(1)).findByProjectIdAndIsActiveTrue(projectAId);
+        verify(projectMemberRoleRepositorySpy, times(1))
+                .findActiveRoleLinksByProjectId(projectAId, ProjectMemberStatus.ACTIVE);
+        verify(projectMemberRoleRepositorySpy, never()).findByProjectMemberIdAndRevokedAtIsNull(any());
+        verify(projectMemberRoleRepositorySpy, never()).findByProjectMemberIdAndRevokedAtIsNull(anyLong());
+    }
+
+    private void setRoleInactive(Role role) {
+        try {
+            Field isActiveField = Role.class.getDeclaredField("isActive");
+            isActiveField.setAccessible(true);
+            isActiveField.set(role, false);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to set role inactive", e);
+        }
+    }
+}


### PR DESCRIPTION
- Query 계층 분리: ProjectMemberQueryService 추가, ACTIVE 멤버 기본 조회 구현  
- 권한 조립 강화: projectId 경계 고정 + 배치 조회로 멤버+권한 스냅샷 구성  
- 응답 모델 분리: 기본/권한포함 read-model DTO 및 내부 projection DTO 추가  
- 테스트 보강: 기본 회귀, 조립 정확성, 대량 조회 N+1 회피 검증 추가  