### PR TITLE
feat(task): 업무 커맨드 API: 생성, 수정, 할당 및 담당, 상태 변경 구현

### DIFF
--- a/src/main/java/com/example/workmanagement/domain/task/domain/model/Task.java
+++ b/src/main/java/com/example/workmanagement/domain/task/domain/model/Task.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -165,6 +166,14 @@ public class Task {
             throw new TaskDomainException(TaskErrorCode.TASK_STATUS_TRANSITION_NOT_ALLOWED);
         }
         this.status = TaskStatus.COMPLETED;
+    }
+
+    public boolean belongsToProject(Long projectId) {
+        return Objects.equals(this.projectId, projectId);
+    }
+
+    public boolean isAuthor(Long userId) {
+        return Objects.equals(this.authorId, userId);
     }
 
     private static Long validatePositiveId(Long id, String fieldName) {

--- a/src/main/java/com/example/workmanagement/domain/task/domain/model/Task.java
+++ b/src/main/java/com/example/workmanagement/domain/task/domain/model/Task.java
@@ -146,6 +146,27 @@ public class Task {
         }
     }
 
+    public void start() {
+        if (status != TaskStatus.PENDING) {
+            throw new TaskDomainException(TaskErrorCode.TASK_STATUS_TRANSITION_NOT_ALLOWED);
+        }
+        this.status = TaskStatus.IN_PROGRESS;
+    }
+
+    public void cancelStart() {
+        if (status != TaskStatus.IN_PROGRESS) {
+            throw new TaskDomainException(TaskErrorCode.TASK_STATUS_TRANSITION_NOT_ALLOWED);
+        }
+        this.status = TaskStatus.PENDING;
+    }
+
+    public void forceComplete() {
+        if (status != TaskStatus.IN_REVIEW) {
+            throw new TaskDomainException(TaskErrorCode.TASK_STATUS_TRANSITION_NOT_ALLOWED);
+        }
+        this.status = TaskStatus.COMPLETED;
+    }
+
     private static Long validatePositiveId(Long id, String fieldName) {
         if (id == null || id <= 0) {
             throw new TaskDomainException(TaskErrorCode.TASK_INVALID_ARGUMENT, fieldName + " must be positive");

--- a/src/main/java/com/example/workmanagement/domain/task/domain/model/Task.java
+++ b/src/main/java/com/example/workmanagement/domain/task/domain/model/Task.java
@@ -136,6 +136,16 @@ public class Task {
         this.priority = priority;
     }
 
+    public void ensureAssignableStatus() {
+        TaskValidators.ensureAssignableStatus(status);
+    }
+
+    public void revertToPendingIfInProgress() {
+        if (status == TaskStatus.IN_PROGRESS) {
+            this.status = TaskStatus.PENDING;
+        }
+    }
+
     private static Long validatePositiveId(Long id, String fieldName) {
         if (id == null || id <= 0) {
             throw new TaskDomainException(TaskErrorCode.TASK_INVALID_ARGUMENT, fieldName + " must be positive");

--- a/src/main/java/com/example/workmanagement/domain/task/domain/model/Task.java
+++ b/src/main/java/com/example/workmanagement/domain/task/domain/model/Task.java
@@ -107,6 +107,35 @@ public class Task {
         return new Task(projectId, authorId, title, description, startDate, dueDate, priority);
     }
 
+    // ----- business methods
+
+    public void updateTitle(String title) {
+        TaskValidators.ensureUpdatableStatus(status);
+        this.title = TaskValidators.normalizeTitle(title);
+    }
+
+    public void updateDescription(String description) {
+        TaskValidators.ensureUpdatableStatus(status);
+        this.description = TaskValidators.normalizeDescription(description);
+    }
+
+    public void updateStartDate(LocalDate startDate) {
+        TaskValidators.ensureUpdatableStatus(status);
+        TaskValidators.validateDateOrder(startDate, dueDate);
+        this.startDate = startDate;
+    }
+
+    public void updateDueDate(LocalDate dueDate) {
+        TaskValidators.ensureUpdatableStatus(status);
+        TaskValidators.validateDateOrder(startDate, dueDate);
+        this.dueDate = dueDate;
+    }
+
+    public void updatePriority(TaskPriority priority) {
+        TaskValidators.ensureUpdatableStatus(status);
+        this.priority = priority;
+    }
+
     private static Long validatePositiveId(Long id, String fieldName) {
         if (id == null || id <= 0) {
             throw new TaskDomainException(TaskErrorCode.TASK_INVALID_ARGUMENT, fieldName + " must be positive");

--- a/src/main/java/com/example/workmanagement/domain/task/domain/model/TaskAssignee.java
+++ b/src/main/java/com/example/workmanagement/domain/task/domain/model/TaskAssignee.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
@@ -61,6 +62,13 @@ public class TaskAssignee {
 
     public static TaskAssignee assign(Long taskId, Long userId, Long assignedBy) {
         return new TaskAssignee(taskId, userId, assignedBy);
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
     }
 
     private static Long validatePositiveId(Long id, String fieldName) {

--- a/src/main/java/com/example/workmanagement/domain/task/domain/model/TaskAssignee.java
+++ b/src/main/java/com/example/workmanagement/domain/task/domain/model/TaskAssignee.java
@@ -1,0 +1,72 @@
+package com.example.workmanagement.domain.task.domain.model;
+
+import com.example.workmanagement.domain.task.error.TaskErrorCode;
+import com.example.workmanagement.domain.task.exception.TaskDomainException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "task_assignees",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_task_assignees_task_user",
+                columnNames = {"task_id", "user_id"}
+        ),
+        indexes = {
+                @Index(name = "idx_task_assignees_user_id", columnList = "user_id")
+        }
+)
+@EntityListeners(AuditingEntityListener.class)
+@Accessors(fluent = true)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TaskAssignee {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "task_id", nullable = false)
+    private Long taskId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "assigned_by", nullable = false)
+    private Long assignedBy;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    private TaskAssignee(Long taskId, Long userId, Long assignedBy) {
+        this.taskId = validatePositiveId(taskId, "taskId");
+        this.userId = validatePositiveId(userId, "userId");
+        this.assignedBy = validatePositiveId(assignedBy, "assignedBy");
+    }
+
+    public static TaskAssignee assign(Long taskId, Long userId, Long assignedBy) {
+        return new TaskAssignee(taskId, userId, assignedBy);
+    }
+
+    private static Long validatePositiveId(Long id, String fieldName) {
+        if (id == null || id <= 0L) {
+            throw new TaskDomainException(TaskErrorCode.TASK_INVALID_ARGUMENT, fieldName + " must be positive");
+        }
+        return id;
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/domain/validation/TaskValidators.java
+++ b/src/main/java/com/example/workmanagement/domain/task/domain/validation/TaskValidators.java
@@ -69,4 +69,14 @@ public final class TaskValidators {
             throw new TaskDomainException(TaskErrorCode.TASK_UPDATE_NOT_ALLOWED);
         }
     }
+
+    public static void ensureAssignableStatus(TaskStatus currentStatus) {
+        if (currentStatus == null) {
+            throw new TaskDomainException(TaskErrorCode.TASK_STATUS_INVALID);
+        }
+
+        if (currentStatus != TaskStatus.PENDING && currentStatus != TaskStatus.IN_PROGRESS) {
+            throw new TaskDomainException(TaskErrorCode.TASK_ASSIGNMENT_NOT_ALLOWED);
+        }
+    }
 }

--- a/src/main/java/com/example/workmanagement/domain/task/error/TaskErrorCode.java
+++ b/src/main/java/com/example/workmanagement/domain/task/error/TaskErrorCode.java
@@ -14,6 +14,7 @@ public enum TaskErrorCode implements ErrorCode {
     TASK_DATE_RANGE_INVALID(HttpStatus.BAD_REQUEST, "업무 시작일은 마감일보다 늦을 수 없습니다."),
     TASK_PRIORITY_INVALID(HttpStatus.BAD_REQUEST, "업무 우선순위 값이 유효하지 않습니다."),
     TASK_STATUS_INVALID(HttpStatus.BAD_REQUEST, "업무 상태 값이 유효하지 않습니다."),
+    TASK_ACTOR_IS_TARGET(HttpStatus.BAD_REQUEST, "할당 요청에서 대상 회원이 자기자신일 수 없습니다."),
 
     TASK_STATUS_TRANSITION_NOT_ALLOWED(HttpStatus.CONFLICT, "현재 상태에서는 요청한 상태 전이가 허용되지 않습니다."),
     TASK_UPDATE_NOT_ALLOWED(HttpStatus.CONFLICT, "현재 상태에서는 업무를 수정할 수 없습니다."),

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/TaskCommandController.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/TaskCommandController.java
@@ -1,0 +1,349 @@
+package com.example.workmanagement.domain.task.presentation;
+
+import com.example.workmanagement.domain.task.presentation.dto.TaskAssignRequest;
+import com.example.workmanagement.domain.task.presentation.dto.TaskCreateRequest;
+import com.example.workmanagement.domain.task.presentation.dto.TaskUnassignRequest;
+import com.example.workmanagement.domain.task.presentation.dto.TaskUpdateDescriptionRequest;
+import com.example.workmanagement.domain.task.presentation.dto.TaskUpdateDueDateRequest;
+import com.example.workmanagement.domain.task.presentation.dto.TaskUpdatePriorityRequest;
+import com.example.workmanagement.domain.task.presentation.dto.TaskUpdateStartDateRequest;
+import com.example.workmanagement.domain.task.presentation.dto.TaskUpdateTitleRequest;
+import com.example.workmanagement.domain.task.service.command.TaskAssignCommand;
+import com.example.workmanagement.domain.task.service.command.TaskAssignMeCommand;
+import com.example.workmanagement.domain.task.service.command.TaskCancelStartCommand;
+import com.example.workmanagement.domain.task.service.command.TaskCreateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskForceCompleteCommand;
+import com.example.workmanagement.domain.task.service.command.TaskStartCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUnassignCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUnassignMeCommand;
+import com.example.workmanagement.domain.task.service.TaskCommandService;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateDescriptionCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateDueDateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdatePriorityCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateStartDateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateTitleCommand;
+import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
+import com.example.workmanagement.global.response.ApiResponse;
+import com.example.workmanagement.global.security.resolver.AuthenticatedUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/projects/{projectId}/tasks")
+@Tag(name = "업무", description = "업무 명령 API")
+public class TaskCommandController {
+
+    private final TaskCommandService taskCommandService;
+
+    public TaskCommandController(TaskCommandService taskCommandService) {
+        this.taskCommandService = taskCommandService;
+    }
+
+    // ----- 업무 생성
+
+    @PostMapping
+    @Operation(summary = "업무 생성", description = "프로젝트 내 새로운 업무를 생성합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> createTask(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Valid
+            @RequestBody
+            TaskCreateRequest request
+    ) {
+        TaskCreateCommand command = request.toCommand(projectId, actorId);
+        TaskDetailResult result = taskCommandService.createTask(command);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(result));
+    }
+
+    // ----- 업무 수정
+
+    @PatchMapping("/{taskId}/title")
+    @Operation(summary = "업무 제목 수정", description = "업무의 제목을 수정합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> updateTaskTitle(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId,
+
+            @Valid @RequestBody
+            TaskUpdateTitleRequest request
+    ) {
+        TaskUpdateTitleCommand command = request.toCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.updateTitle(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PatchMapping("/{taskId}/description")
+    @Operation(summary = "업무 설명 수정", description = "업무의 설명을 수정합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> updateTaskDescription(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId,
+
+            @Valid @RequestBody
+            TaskUpdateDescriptionRequest request
+    ) {
+        TaskUpdateDescriptionCommand command = request.toCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.updateDescription(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PatchMapping("/{taskId}/start-date")
+    @Operation(summary = "업무 시작일 수정", description = "업무의 시작일을 수정합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> updateTaskStartDate(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId,
+
+            @Valid @RequestBody
+            TaskUpdateStartDateRequest request
+    ) {
+        TaskUpdateStartDateCommand command = request.toCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.updateStartDate(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PatchMapping("/{taskId}/due-date")
+    @Operation(summary = "업무 마감일 수정", description = "업무의 마감일을 수정합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> updateTaskDueDate(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId,
+
+            @Valid @RequestBody
+            TaskUpdateDueDateRequest request
+    ) {
+        TaskUpdateDueDateCommand command = request.toCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.updateDueDate(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PatchMapping("/{taskId}/priority")
+    @Operation(summary = "업무 우선순위 수정", description = "업무의 우선순위를 수정합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> updateTaskPriority(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId,
+
+            @Valid @RequestBody
+            TaskUpdatePriorityRequest request
+    ) {
+        TaskUpdatePriorityCommand command = request.toCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.updatePriority(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    // ----- 업무 할당 및 담당
+
+    @PostMapping("/{taskId}/assign")
+    @Operation(summary = "업무 할당", description = "다른 사용자를 업무 담당자로 지정합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> assignTask(
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable Long taskId,
+            @Valid @RequestBody TaskAssignRequest request
+    ) {
+        TaskAssignCommand command = request.toCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.assignTask(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PostMapping("/{taskId}/assign/me")
+    @Operation(summary = "업무 담당", description = "본인을 업무 담당자로 지정합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> assignMe(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId
+    ) {
+        TaskAssignMeCommand command = new TaskAssignMeCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.assignMe(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PostMapping("/{taskId}/unassign")
+    @Operation(summary = "업무 할당 해제", description = "지정한 담당자를 업무에서 해제합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> unassignTask(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId,
+
+            @Valid @RequestBody
+            TaskUnassignRequest request
+    ) {
+        TaskUnassignCommand command = request.toCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.unassignTask(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PostMapping("/{taskId}/unassign/me")
+    @Operation(summary = "업무 담당 해제", description = "본인 담당을 해제합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> unassignMe(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId
+    ) {
+        TaskUnassignMeCommand command = new TaskUnassignMeCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.unassignMe(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    // ----- 업무 상태 변경
+
+    @PostMapping("/{taskId}/start")
+    @Operation(summary = "업무 시작", description = "업무 상태를 PENDING에서 IN_PROGRESS로 전이합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> startTask(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId
+    ) {
+        TaskStartCommand command = new TaskStartCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.startTask(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PostMapping("/{taskId}/cancel-start")
+    @Operation(summary = "업무 시작 취소", description = "업무 상태를 IN_PROGRESS에서 PENDING으로 전이합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> cancelStartTask(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId
+    ) {
+        TaskCancelStartCommand command = new TaskCancelStartCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.cancelStartTask(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PostMapping("/{taskId}/force-complete")
+    @Operation(summary = "업무 강제 완료", description = "업무 상태를 IN_REVIEW에서 COMPLETED로 강제 전이합니다.")
+    public ResponseEntity<ApiResponse<TaskDetailResult>> forceCompleteTask(
+
+            @Parameter(hidden = true)
+            @AuthenticatedUserId
+            Long actorId,
+
+            @Parameter(description = "프로젝트 ID", example = "10")
+            @PathVariable
+            Long projectId,
+
+            @Parameter(description = "업무 ID", example = "100")
+            @PathVariable
+            Long taskId
+    ) {
+        TaskForceCompleteCommand command = new TaskForceCompleteCommand(projectId, taskId, actorId);
+        TaskDetailResult result = taskCommandService.forceCompleteTask(command);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/TaskQueryController.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/TaskQueryController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/projects/{projectId}/tasks")
+@RequestMapping("/api/projects/{projectId}/tasks")
 @Tag(name = "업무", description = "업무 조회 API")
 public class TaskQueryController {
 

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/TaskQueryController.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/TaskQueryController.java
@@ -24,11 +24,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/projects/{projectId}/tasks")
 @Tag(name = "업무", description = "업무 조회 API")
-public class TaskController {
+public class TaskQueryController {
 
     private final TaskQueryService taskQueryService;
 
-    public TaskController(TaskQueryService taskQueryService) {
+    public TaskQueryController(TaskQueryService taskQueryService) {
         this.taskQueryService = taskQueryService;
     }
 

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskAssignRequest.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskAssignRequest.java
@@ -1,0 +1,17 @@
+package com.example.workmanagement.domain.task.presentation.dto;
+
+import com.example.workmanagement.domain.task.service.command.TaskAssignCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+@Schema(description = "업무 할당 요청")
+public record TaskAssignRequest(
+        @Schema(description = "할당할 사용자 ID", example = "102")
+        @NotNull @Positive Long userId
+) {
+
+    public TaskAssignCommand toCommand(Long projectId, Long taskId, Long actorId) {
+        return new TaskAssignCommand(projectId, taskId, actorId, userId);
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskCreateRequest.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskCreateRequest.java
@@ -1,0 +1,34 @@
+package com.example.workmanagement.domain.task.presentation.dto;
+
+import com.example.workmanagement.domain.task.domain.model.TaskPriority;
+import com.example.workmanagement.domain.task.service.command.TaskCreateCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+
+@Schema(description = "업무 생성 요청")
+public record TaskCreateRequest(
+        @Schema(description = "업무 제목", example = "백엔드 API 설계")
+        @NotBlank String title,
+        @Schema(description = "업무 설명")
+        String description,
+        @Schema(description = "시작일", example = "2026-03-17")
+        LocalDate startDate,
+        @Schema(description = "마감일", example = "2026-03-20")
+        LocalDate dueDate,
+        @Schema(description = "업무 우선순위", example = "HIGH")
+        TaskPriority priority
+) {
+
+    public TaskCreateCommand toCommand(Long projectId, Long actorId) {
+        return new TaskCreateCommand(
+                projectId,
+                actorId,
+                title,
+                description,
+                startDate,
+                dueDate,
+                priority
+        );
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUnassignRequest.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUnassignRequest.java
@@ -1,0 +1,17 @@
+package com.example.workmanagement.domain.task.presentation.dto;
+
+import com.example.workmanagement.domain.task.service.command.TaskUnassignCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+@Schema(description = "업무 할당 해제 요청")
+public record TaskUnassignRequest(
+        @Schema(description = "해제할 사용자 ID", example = "102")
+        @NotNull @Positive Long userId
+) {
+
+    public TaskUnassignCommand toCommand(Long projectId, Long taskId, Long actorId) {
+        return new TaskUnassignCommand(projectId, taskId, actorId, userId);
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUpdateDescriptionRequest.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUpdateDescriptionRequest.java
@@ -1,0 +1,15 @@
+package com.example.workmanagement.domain.task.presentation.dto;
+
+import com.example.workmanagement.domain.task.service.command.TaskUpdateDescriptionCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "업무 설명 수정 요청")
+public record TaskUpdateDescriptionRequest(
+        @Schema(description = "업무 설명")
+        String description
+) {
+
+    public TaskUpdateDescriptionCommand toCommand(Long projectId, Long taskId, Long actorId) {
+        return new TaskUpdateDescriptionCommand(projectId, taskId, actorId, description);
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUpdateDueDateRequest.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUpdateDueDateRequest.java
@@ -1,0 +1,16 @@
+package com.example.workmanagement.domain.task.presentation.dto;
+
+import com.example.workmanagement.domain.task.service.command.TaskUpdateDueDateCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+@Schema(description = "업무 마감일 수정 요청")
+public record TaskUpdateDueDateRequest(
+        @Schema(description = "마감일", example = "2026-03-22")
+        LocalDate dueDate
+) {
+
+    public TaskUpdateDueDateCommand toCommand(Long projectId, Long taskId, Long actorId) {
+        return new TaskUpdateDueDateCommand(projectId, taskId, actorId, dueDate);
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUpdatePriorityRequest.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUpdatePriorityRequest.java
@@ -1,0 +1,16 @@
+package com.example.workmanagement.domain.task.presentation.dto;
+
+import com.example.workmanagement.domain.task.domain.model.TaskPriority;
+import com.example.workmanagement.domain.task.service.command.TaskUpdatePriorityCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "업무 우선순위 수정 요청")
+public record TaskUpdatePriorityRequest(
+        @Schema(description = "업무 우선순위", example = "MEDIUM")
+        TaskPriority priority
+) {
+
+    public TaskUpdatePriorityCommand toCommand(Long projectId, Long taskId, Long actorId) {
+        return new TaskUpdatePriorityCommand(projectId, taskId, actorId, priority);
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUpdateStartDateRequest.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUpdateStartDateRequest.java
@@ -1,0 +1,16 @@
+package com.example.workmanagement.domain.task.presentation.dto;
+
+import com.example.workmanagement.domain.task.service.command.TaskUpdateStartDateCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+@Schema(description = "업무 시작일 수정 요청")
+public record TaskUpdateStartDateRequest(
+        @Schema(description = "시작일", example = "2026-03-18")
+        LocalDate startDate
+) {
+
+    public TaskUpdateStartDateCommand toCommand(Long projectId, Long taskId, Long actorId) {
+        return new TaskUpdateStartDateCommand(projectId, taskId, actorId, startDate);
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUpdateTitleRequest.java
+++ b/src/main/java/com/example/workmanagement/domain/task/presentation/dto/TaskUpdateTitleRequest.java
@@ -1,0 +1,16 @@
+package com.example.workmanagement.domain.task.presentation.dto;
+
+import com.example.workmanagement.domain.task.service.command.TaskUpdateTitleCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "업무 제목 수정 요청")
+public record TaskUpdateTitleRequest(
+        @Schema(description = "업무 제목", example = "수정된 업무 제목")
+        @NotBlank String title
+) {
+
+    public TaskUpdateTitleCommand toCommand(Long projectId, Long taskId, Long actorId) {
+        return new TaskUpdateTitleCommand(projectId, taskId, actorId, title);
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/repository/TaskAssigneeRepository.java
+++ b/src/main/java/com/example/workmanagement/domain/task/repository/TaskAssigneeRepository.java
@@ -1,0 +1,14 @@
+package com.example.workmanagement.domain.task.repository;
+
+import com.example.workmanagement.domain.task.domain.model.TaskAssignee;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskAssigneeRepository extends JpaRepository<TaskAssignee, Long> {
+
+    boolean existsByTaskIdAndUserId(Long taskId, Long userId);
+
+    Optional<TaskAssignee> findByTaskIdAndUserId(Long taskId, Long userId);
+
+    long countByTaskId(Long taskId);
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/TaskCommandService.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/TaskCommandService.java
@@ -1,6 +1,8 @@
 package com.example.workmanagement.domain.task.service;
 
+import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
 import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
+import com.example.workmanagement.domain.task.domain.model.Task;
 import com.example.workmanagement.domain.task.error.TaskErrorCode;
 import com.example.workmanagement.domain.task.exception.TaskDomainException;
 import com.example.workmanagement.domain.task.repository.TaskRepository;
@@ -19,6 +21,9 @@ import com.example.workmanagement.domain.task.service.command.TaskUpdateStartDat
 import com.example.workmanagement.domain.task.service.command.TaskUpdateTitleCommand;
 import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
 import com.example.workmanagement.global.authorization.PermissionChecker;
+import com.example.workmanagement.global.authorization.permission.TaskPermission;
+import java.util.Objects;
+import java.util.function.Consumer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,29 +48,72 @@ public class TaskCommandService {
     // ----- 업무 생성
 
     public TaskDetailResult createTask(TaskCreateCommand command) {
-        throw notImplemented("createTask");
+        requireCommand(command, "createTask");
+
+        validatePositiveId(command.projectId(), "projectId");
+        validatePositiveId(command.actorId(), "actorId");
+
+        ensureProjectMembership(command.projectId(), command.actorId());
+        ensureCreatePermission(command.projectId(), command.actorId());
+
+        Task created = taskRepository.save(Task.createNew(
+                command.projectId(),
+                command.actorId(),
+                command.title(),
+                command.description(),
+                command.startDate(),
+                command.dueDate(),
+                command.priority()
+        ));
+
+        return loadTaskDetail(created.id());
     }
 
     // ----- 업무 수정
 
     public TaskDetailResult updateTitle(TaskUpdateTitleCommand command) {
-        throw notImplemented("updateTitle");
+        requireCommand(command, "updateTitle");
+        return updateTask(command.projectId(), command.taskId(), command.actorId(), task -> task.updateTitle(command.title()));
     }
 
     public TaskDetailResult updateDescription(TaskUpdateDescriptionCommand command) {
-        throw notImplemented("updateDescription");
+        requireCommand(command, "updateDescription");
+        return updateTask(
+                command.projectId(),
+                command.taskId(),
+                command.actorId(),
+                task -> task.updateDescription(command.description())
+        );
     }
 
     public TaskDetailResult updateStartDate(TaskUpdateStartDateCommand command) {
-        throw notImplemented("updateStartDate");
+        requireCommand(command, "updateStartDate");
+        return updateTask(
+                command.projectId(),
+                command.taskId(),
+                command.actorId(),
+                task -> task.updateStartDate(command.startDate())
+        );
     }
 
     public TaskDetailResult updateDueDate(TaskUpdateDueDateCommand command) {
-        throw notImplemented("updateDueDate");
+        requireCommand(command, "updateDueDate");
+        return updateTask(
+                command.projectId(),
+                command.taskId(),
+                command.actorId(),
+                task -> task.updateDueDate(command.dueDate())
+        );
     }
 
     public TaskDetailResult updatePriority(TaskUpdatePriorityCommand command) {
-        throw notImplemented("updatePriority");
+        requireCommand(command, "updatePriority");
+        return updateTask(
+                command.projectId(),
+                command.taskId(),
+                command.actorId(),
+                task -> task.updatePriority(command.priority())
+        );
     }
 
     // ----- 업무 할당 및 담당
@@ -102,10 +150,87 @@ public class TaskCommandService {
 
     // ----- helpers
 
+    private TaskDetailResult updateTask(Long projectId, Long taskId, Long actorId, Consumer<Task> updater) {
+        validatePositiveId(projectId, "projectId");
+        validatePositiveId(taskId, "taskId");
+        validatePositiveId(actorId, "actorId");
+
+        ensureProjectMembership(projectId, actorId);
+
+        Task task = loadTaskInProject(projectId, taskId);
+        ensureUpdatePermission(task, actorId);
+
+        updater.accept(task);
+
+        return loadTaskDetail(task.id());
+    }
+
+    private Task loadTaskInProject(Long projectId, Long taskId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new TaskDomainException(TaskErrorCode.TASK_NOT_FOUND));
+
+        if (!Objects.equals(task.projectId(), projectId)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_NOT_FOUND);
+        }
+
+        return task;
+    }
+
+    private TaskDetailResult loadTaskDetail(Long taskId) {
+        return taskRepository.findDetailById(taskId)
+                .orElseThrow(() -> new TaskDomainException(
+                        TaskErrorCode.TASK_INTERNAL_SERVER_ERROR,
+                        "failed to load task detail"
+                ));
+    }
+
+    private void ensureProjectMembership(Long projectId, Long actorId) {
+        boolean isActiveMember = projectMemberRepository
+                .findByProjectIdAndUserIdAndStatus(projectId, actorId, ProjectMemberStatus.ACTIVE)
+                .isPresent();
+
+        if (!isActiveMember) {
+            throw new TaskDomainException(TaskErrorCode.TASK_PROJECT_MEMBERSHIP_REQUIRED);
+        }
+    }
+
+    private void ensureCreatePermission(Long projectId, Long actorId) {
+        if (!permissionChecker.hasTaskPermission(projectId, actorId, TaskPermission.TASK_CREATE)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_CREATE_FORBIDDEN);
+        }
+    }
+
+    private void ensureUpdatePermission(Task task, Long actorId) {
+        if (Objects.equals(task.authorId(), actorId)) {
+            return;
+        }
+
+        if (permissionChecker.hasTaskPermission(task.projectId(), actorId, TaskPermission.TASK_OVERWRITE)) {
+            return;
+        }
+
+        throw new TaskDomainException(TaskErrorCode.TASK_UPDATE_FORBIDDEN);
+    }
+
+    private static void requireCommand(Object command, String operation) {
+        if (command == null) {
+            throw new TaskDomainException(
+                    TaskErrorCode.TASK_INVALID_ARGUMENT,
+                    operation + " command must not be null"
+            );
+        }
+    }
+
+    private static void validatePositiveId(Long id, String fieldName) {
+        if (id == null || id <= 0L) {
+            throw new TaskDomainException(TaskErrorCode.TASK_INVALID_ARGUMENT, fieldName + " must be positive");
+        }
+    }
+
     private static TaskDomainException notImplemented(String operation) {
         return new TaskDomainException(
                 TaskErrorCode.TASK_INTERNAL_SERVER_ERROR,
-                operation + " 구현 안 하면 에러낼거임"
+                operation + " command is not implemented yet"
         );
     }
 }

--- a/src/main/java/com/example/workmanagement/domain/task/service/TaskCommandService.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/TaskCommandService.java
@@ -147,15 +147,52 @@ public class TaskCommandService {
     // ----- 업무 상태 변경
 
     public TaskDetailResult startTask(TaskStartCommand command) {
-        throw notImplemented("startTask");
+        requireCommand(command, "startTask");
+
+        validatePositiveId(command.projectId(), "projectId");
+        validatePositiveId(command.taskId(), "taskId");
+        validatePositiveId(command.actorId(), "actorId");
+
+        ensureProjectMembership(command.projectId(), command.actorId());
+
+        Task task = loadTaskInProject(command.projectId(), command.taskId());
+        ensureTaskHasAssignee(task.id());
+        ensureStartPermission(task.id(), command.actorId());
+
+        task.start();
+        return loadTaskDetail(task.id());
     }
 
     public TaskDetailResult cancelStartTask(TaskCancelStartCommand command) {
-        throw notImplemented("cancelStartTask");
+        requireCommand(command, "cancelStartTask");
+
+        validatePositiveId(command.projectId(), "projectId");
+        validatePositiveId(command.taskId(), "taskId");
+        validatePositiveId(command.actorId(), "actorId");
+
+        ensureProjectMembership(command.projectId(), command.actorId());
+
+        Task task = loadTaskInProject(command.projectId(), command.taskId());
+        ensureStartPermission(task.id(), command.actorId());
+
+        task.cancelStart();
+        return loadTaskDetail(task.id());
     }
 
     public TaskDetailResult forceCompleteTask(TaskForceCompleteCommand command) {
-        throw notImplemented("forceCompleteTask");
+        requireCommand(command, "forceCompleteTask");
+
+        validatePositiveId(command.projectId(), "projectId");
+        validatePositiveId(command.taskId(), "taskId");
+        validatePositiveId(command.actorId(), "actorId");
+
+        ensureProjectMembership(command.projectId(), command.actorId());
+        ensureForceCompletePermission(command.projectId(), command.actorId());
+
+        Task task = loadTaskInProject(command.projectId(), command.taskId());
+        task.forceComplete();
+
+        return loadTaskDetail(task.id());
     }
 
     // ----- helpers
@@ -267,6 +304,24 @@ public class TaskCommandService {
         }
     }
 
+    private void ensureStartPermission(Long taskId, Long actorId) {
+        if (!taskAssigneeRepository.existsByTaskIdAndUserId(taskId, actorId)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_START_FORBIDDEN);
+        }
+    }
+
+    private void ensureTaskHasAssignee(Long taskId) {
+        if (taskAssigneeRepository.countByTaskId(taskId) <= 0L) {
+            throw new TaskDomainException(TaskErrorCode.TASK_STATUS_TRANSITION_NOT_ALLOWED);
+        }
+    }
+
+    private void ensureForceCompletePermission(Long projectId, Long actorId) {
+        if (!permissionChecker.hasTaskPermission(projectId, actorId, TaskPermission.TASK_FORCE_COMPLETE)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_FORCE_COMPLETE_FORBIDDEN);
+        }
+    }
+
     private void ensureUpdatePermission(Task task, Long actorId) {
         if (Objects.equals(task.authorId(), actorId)) {
             return;
@@ -294,10 +349,4 @@ public class TaskCommandService {
         }
     }
 
-    private static TaskDomainException notImplemented(String operation) {
-        return new TaskDomainException(
-                TaskErrorCode.TASK_INTERNAL_SERVER_ERROR,
-                operation + " command is not implemented yet"
-        );
-    }
 }

--- a/src/main/java/com/example/workmanagement/domain/task/service/TaskCommandService.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/TaskCommandService.java
@@ -1,0 +1,111 @@
+package com.example.workmanagement.domain.task.service;
+
+import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
+import com.example.workmanagement.domain.task.error.TaskErrorCode;
+import com.example.workmanagement.domain.task.exception.TaskDomainException;
+import com.example.workmanagement.domain.task.repository.TaskRepository;
+import com.example.workmanagement.domain.task.service.command.TaskAssignCommand;
+import com.example.workmanagement.domain.task.service.command.TaskAssignMeCommand;
+import com.example.workmanagement.domain.task.service.command.TaskCancelStartCommand;
+import com.example.workmanagement.domain.task.service.command.TaskCreateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskForceCompleteCommand;
+import com.example.workmanagement.domain.task.service.command.TaskStartCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUnassignCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUnassignMeCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateDescriptionCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateDueDateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdatePriorityCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateStartDateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateTitleCommand;
+import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
+import com.example.workmanagement.global.authorization.PermissionChecker;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class TaskCommandService {
+
+    private final TaskRepository taskRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final PermissionChecker permissionChecker;
+
+    public TaskCommandService(
+            TaskRepository taskRepository,
+            ProjectMemberRepository projectMemberRepository,
+            PermissionChecker permissionChecker
+    ) {
+        this.taskRepository = taskRepository;
+        this.projectMemberRepository = projectMemberRepository;
+        this.permissionChecker = permissionChecker;
+    }
+
+    // ----- 업무 생성
+
+    public TaskDetailResult createTask(TaskCreateCommand command) {
+        throw notImplemented("createTask");
+    }
+
+    // ----- 업무 수정
+
+    public TaskDetailResult updateTitle(TaskUpdateTitleCommand command) {
+        throw notImplemented("updateTitle");
+    }
+
+    public TaskDetailResult updateDescription(TaskUpdateDescriptionCommand command) {
+        throw notImplemented("updateDescription");
+    }
+
+    public TaskDetailResult updateStartDate(TaskUpdateStartDateCommand command) {
+        throw notImplemented("updateStartDate");
+    }
+
+    public TaskDetailResult updateDueDate(TaskUpdateDueDateCommand command) {
+        throw notImplemented("updateDueDate");
+    }
+
+    public TaskDetailResult updatePriority(TaskUpdatePriorityCommand command) {
+        throw notImplemented("updatePriority");
+    }
+
+    // ----- 업무 할당 및 담당
+
+    public TaskDetailResult assignTask(TaskAssignCommand command) {
+        throw notImplemented("assignTask");
+    }
+
+    public TaskDetailResult assignMe(TaskAssignMeCommand command) {
+        throw notImplemented("assignMe");
+    }
+
+    public TaskDetailResult unassignTask(TaskUnassignCommand command) {
+        throw notImplemented("unassignTask");
+    }
+
+    public TaskDetailResult unassignMe(TaskUnassignMeCommand command) {
+        throw notImplemented("unassignMe");
+    }
+
+    // ----- 업무 상태 변경
+
+    public TaskDetailResult startTask(TaskStartCommand command) {
+        throw notImplemented("startTask");
+    }
+
+    public TaskDetailResult cancelStartTask(TaskCancelStartCommand command) {
+        throw notImplemented("cancelStartTask");
+    }
+
+    public TaskDetailResult forceCompleteTask(TaskForceCompleteCommand command) {
+        throw notImplemented("forceCompleteTask");
+    }
+
+    // ----- helpers
+
+    private static TaskDomainException notImplemented(String operation) {
+        return new TaskDomainException(
+                TaskErrorCode.TASK_INTERNAL_SERVER_ERROR,
+                operation + " 구현 안 하면 에러낼거임"
+        );
+    }
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/TaskCommandService.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/TaskCommandService.java
@@ -2,9 +2,11 @@ package com.example.workmanagement.domain.task.service;
 
 import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
 import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
+import com.example.workmanagement.domain.task.domain.model.TaskAssignee;
 import com.example.workmanagement.domain.task.domain.model.Task;
 import com.example.workmanagement.domain.task.error.TaskErrorCode;
 import com.example.workmanagement.domain.task.exception.TaskDomainException;
+import com.example.workmanagement.domain.task.repository.TaskAssigneeRepository;
 import com.example.workmanagement.domain.task.repository.TaskRepository;
 import com.example.workmanagement.domain.task.service.command.TaskAssignCommand;
 import com.example.workmanagement.domain.task.service.command.TaskAssignMeCommand;
@@ -24,6 +26,7 @@ import com.example.workmanagement.global.authorization.PermissionChecker;
 import com.example.workmanagement.global.authorization.permission.TaskPermission;
 import java.util.Objects;
 import java.util.function.Consumer;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,15 +35,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class TaskCommandService {
 
     private final TaskRepository taskRepository;
+    private final TaskAssigneeRepository taskAssigneeRepository;
     private final ProjectMemberRepository projectMemberRepository;
     private final PermissionChecker permissionChecker;
 
     public TaskCommandService(
             TaskRepository taskRepository,
+            TaskAssigneeRepository taskAssigneeRepository,
             ProjectMemberRepository projectMemberRepository,
             PermissionChecker permissionChecker
     ) {
         this.taskRepository = taskRepository;
+        this.taskAssigneeRepository = taskAssigneeRepository;
         this.projectMemberRepository = projectMemberRepository;
         this.permissionChecker = permissionChecker;
     }
@@ -119,19 +125,23 @@ public class TaskCommandService {
     // ----- 업무 할당 및 담당
 
     public TaskDetailResult assignTask(TaskAssignCommand command) {
-        throw notImplemented("assignTask");
+        requireCommand(command, "assignTask");
+        return assignTaskInternal(command.projectId(), command.taskId(), command.actorId(), command.userId());
     }
 
     public TaskDetailResult assignMe(TaskAssignMeCommand command) {
-        throw notImplemented("assignMe");
+        requireCommand(command, "assignMe");
+        return assignTaskInternal(command.projectId(), command.taskId(), command.actorId(), command.actorId());
     }
 
     public TaskDetailResult unassignTask(TaskUnassignCommand command) {
-        throw notImplemented("unassignTask");
+        requireCommand(command, "unassignTask");
+        return unassignTaskInternal(command.projectId(), command.taskId(), command.actorId(), command.userId());
     }
 
     public TaskDetailResult unassignMe(TaskUnassignMeCommand command) {
-        throw notImplemented("unassignMe");
+        requireCommand(command, "unassignMe");
+        return unassignTaskInternal(command.projectId(), command.taskId(), command.actorId(), command.actorId());
     }
 
     // ----- 업무 상태 변경
@@ -161,6 +171,57 @@ public class TaskCommandService {
         ensureUpdatePermission(task, actorId);
 
         updater.accept(task);
+
+        return loadTaskDetail(task.id());
+    }
+
+    private TaskDetailResult assignTaskInternal(Long projectId, Long taskId, Long actorId, Long targetUserId) {
+        validatePositiveId(projectId, "projectId");
+        validatePositiveId(taskId, "taskId");
+        validatePositiveId(actorId, "actorId");
+        validatePositiveId(targetUserId, "targetUserId");
+
+        ensureProjectMembership(projectId, actorId);
+        ensureAssignPermission(projectId, actorId);
+        ensureProjectMembership(projectId, targetUserId);
+
+        Task task = loadTaskInProject(projectId, taskId);
+        task.ensureAssignableStatus();
+
+        if (taskAssigneeRepository.existsByTaskIdAndUserId(task.id(), targetUserId)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_ALREADY_ASSIGNED);
+        }
+
+        try {
+            taskAssigneeRepository.save(TaskAssignee.assign(task.id(), targetUserId, actorId));
+        } catch (DataIntegrityViolationException exception) {
+            throw new TaskDomainException(TaskErrorCode.TASK_ALREADY_ASSIGNED);
+        }
+
+        return loadTaskDetail(task.id());
+    }
+
+    private TaskDetailResult unassignTaskInternal(Long projectId, Long taskId, Long actorId, Long targetUserId) {
+        validatePositiveId(projectId, "projectId");
+        validatePositiveId(taskId, "taskId");
+        validatePositiveId(actorId, "actorId");
+        validatePositiveId(targetUserId, "targetUserId");
+
+        ensureProjectMembership(projectId, actorId);
+        ensureAssignPermission(projectId, actorId);
+
+        Task task = loadTaskInProject(projectId, taskId);
+        task.ensureAssignableStatus();
+
+        TaskAssignee taskAssignee = taskAssigneeRepository.findByTaskIdAndUserId(task.id(), targetUserId)
+                .orElseThrow(() -> new TaskDomainException(TaskErrorCode.TASK_ASSIGNEE_NOT_ASSIGNED));
+
+        taskAssigneeRepository.delete(taskAssignee);
+
+        long remainingAssigneeCount = taskAssigneeRepository.countByTaskId(task.id());
+        if (remainingAssigneeCount == 0L) {
+            task.revertToPendingIfInProgress();
+        }
 
         return loadTaskDetail(task.id());
     }
@@ -197,6 +258,12 @@ public class TaskCommandService {
     private void ensureCreatePermission(Long projectId, Long actorId) {
         if (!permissionChecker.hasTaskPermission(projectId, actorId, TaskPermission.TASK_CREATE)) {
             throw new TaskDomainException(TaskErrorCode.TASK_CREATE_FORBIDDEN);
+        }
+    }
+
+    private void ensureAssignPermission(Long projectId, Long actorId) {
+        if (!permissionChecker.hasTaskPermission(projectId, actorId, TaskPermission.TASK_ASSIGN)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_ASSIGN_FORBIDDEN);
         }
     }
 

--- a/src/main/java/com/example/workmanagement/domain/task/service/TaskCommandService.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/TaskCommandService.java
@@ -72,7 +72,7 @@ public class TaskCommandService {
                 command.priority()
         ));
 
-        return loadTaskDetail(created.id());
+        return loadTaskDetail(created);
     }
 
     // ----- 업무 수정
@@ -126,22 +126,133 @@ public class TaskCommandService {
 
     public TaskDetailResult assignTask(TaskAssignCommand command) {
         requireCommand(command, "assignTask");
-        return assignTaskInternal(command.projectId(), command.taskId(), command.actorId(), command.userId());
+
+        Long projectId = command.projectId();
+        Long taskId = command.taskId();
+        Long actorId = command.actorId();
+        Long targetUserId = command.userId();
+
+        if (Objects.equals(actorId, targetUserId)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_ACTOR_IS_TARGET);
+        }
+
+        validatePositiveId(projectId, "projectId");
+        validatePositiveId(taskId, "taskId");
+        validatePositiveId(actorId, "actorId");
+        validatePositiveId(targetUserId, "targetUserId");
+
+        ensureProjectMembership(projectId, actorId);
+        ensureAssignPermission(projectId, actorId);
+        ensureProjectMembership(projectId, targetUserId);
+
+        Task task = loadTaskInProject(projectId, taskId);
+        task.ensureAssignableStatus();
+
+        if (taskAssigneeRepository.existsByTaskIdAndUserId(taskId, targetUserId)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_ALREADY_ASSIGNED);
+        }
+
+        try {
+            taskAssigneeRepository.save(TaskAssignee.assign(taskId, targetUserId, actorId));
+        } catch (DataIntegrityViolationException exception) {
+            throw new TaskDomainException(TaskErrorCode.TASK_ALREADY_ASSIGNED);
+        }
+
+        return loadTaskDetail(task);
     }
 
     public TaskDetailResult assignMe(TaskAssignMeCommand command) {
         requireCommand(command, "assignMe");
-        return assignTaskInternal(command.projectId(), command.taskId(), command.actorId(), command.actorId());
+
+        Long projectId = command.projectId();
+        Long taskId = command.taskId();
+        Long actorId = command.actorId();
+
+        validatePositiveId(projectId, "projectId");
+        validatePositiveId(taskId, "taskId");
+        validatePositiveId(actorId, "actorId");
+
+        ensureProjectMembership(projectId, actorId);
+
+        Task task = loadTaskInProject(projectId, taskId);
+        task.ensureAssignableStatus();
+
+        if (taskAssigneeRepository.existsByTaskIdAndUserId(taskId, actorId)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_ALREADY_ASSIGNED);
+        }
+
+        try {
+            taskAssigneeRepository.save(TaskAssignee.assign(taskId, actorId, actorId));
+        } catch (DataIntegrityViolationException exception) {
+            throw new TaskDomainException(TaskErrorCode.TASK_ALREADY_ASSIGNED);
+        }
+
+        return loadTaskDetail(task);
     }
 
     public TaskDetailResult unassignTask(TaskUnassignCommand command) {
         requireCommand(command, "unassignTask");
-        return unassignTaskInternal(command.projectId(), command.taskId(), command.actorId(), command.userId());
+
+        Long projectId = command.projectId();
+        Long taskId = command.taskId();
+        Long actorId = command.actorId();
+        Long targetUserId = command.userId();
+
+        if (Objects.equals(actorId, targetUserId)) {
+            throw new TaskDomainException(TaskErrorCode.TASK_ACTOR_IS_TARGET);
+        }
+
+        validatePositiveId(projectId, "projectId");
+        validatePositiveId(taskId, "taskId");
+        validatePositiveId(actorId, "actorId");
+        validatePositiveId(targetUserId, "targetUserId");
+
+        ensureProjectMembership(projectId, actorId);
+        ensureAssignPermission(projectId, actorId);
+
+        Task task = loadTaskInProject(projectId, taskId);
+        task.ensureAssignableStatus();
+
+        TaskAssignee taskAssignee = taskAssigneeRepository.findByTaskIdAndUserId(taskId, targetUserId)
+                .orElseThrow(() -> new TaskDomainException(TaskErrorCode.TASK_ASSIGNEE_NOT_ASSIGNED));
+
+        taskAssigneeRepository.delete(taskAssignee);
+
+        long remainingAssigneeCount = taskAssigneeRepository.countByTaskId(taskId);
+        if (remainingAssigneeCount == 0L) {
+            task.revertToPendingIfInProgress();
+        }
+
+        return loadTaskDetail(task);
     }
 
     public TaskDetailResult unassignMe(TaskUnassignMeCommand command) {
         requireCommand(command, "unassignMe");
-        return unassignTaskInternal(command.projectId(), command.taskId(), command.actorId(), command.actorId());
+
+        Long projectId = command.projectId();
+        Long taskId = command.taskId();
+        Long actorId = command.actorId();
+
+        validatePositiveId(projectId, "projectId");
+        validatePositiveId(taskId, "taskId");
+        validatePositiveId(actorId, "actorId");
+
+        ensureProjectMembership(projectId, actorId);
+
+        Task task = loadTaskInProject(projectId, taskId);
+        task.ensureAssignableStatus();
+
+        TaskAssignee taskAssignee = taskAssigneeRepository.findByTaskIdAndUserId(taskId, actorId)
+                .orElseThrow(() -> new TaskDomainException(TaskErrorCode.TASK_ASSIGNEE_NOT_ASSIGNED));
+
+        taskAssigneeRepository.delete(taskAssignee);
+
+        long remainingAssigneeCount = taskAssigneeRepository.countByTaskId(taskId);
+        if (remainingAssigneeCount == 0L) {
+            task.revertToPendingIfInProgress();
+        }
+
+        return loadTaskDetail(task);
     }
 
     // ----- 업무 상태 변경
@@ -160,7 +271,7 @@ public class TaskCommandService {
         ensureStartPermission(task.id(), command.actorId());
 
         task.start();
-        return loadTaskDetail(task.id());
+        return loadTaskDetail(task);
     }
 
     public TaskDetailResult cancelStartTask(TaskCancelStartCommand command) {
@@ -176,7 +287,7 @@ public class TaskCommandService {
         ensureStartPermission(task.id(), command.actorId());
 
         task.cancelStart();
-        return loadTaskDetail(task.id());
+        return loadTaskDetail(task);
     }
 
     public TaskDetailResult forceCompleteTask(TaskForceCompleteCommand command) {
@@ -192,7 +303,7 @@ public class TaskCommandService {
         Task task = loadTaskInProject(command.projectId(), command.taskId());
         task.forceComplete();
 
-        return loadTaskDetail(task.id());
+        return loadTaskDetail(task);
     }
 
     // ----- helpers
@@ -209,77 +320,34 @@ public class TaskCommandService {
 
         updater.accept(task);
 
-        return loadTaskDetail(task.id());
-    }
-
-    private TaskDetailResult assignTaskInternal(Long projectId, Long taskId, Long actorId, Long targetUserId) {
-        validatePositiveId(projectId, "projectId");
-        validatePositiveId(taskId, "taskId");
-        validatePositiveId(actorId, "actorId");
-        validatePositiveId(targetUserId, "targetUserId");
-
-        ensureProjectMembership(projectId, actorId);
-        ensureAssignPermission(projectId, actorId);
-        ensureProjectMembership(projectId, targetUserId);
-
-        Task task = loadTaskInProject(projectId, taskId);
-        task.ensureAssignableStatus();
-
-        if (taskAssigneeRepository.existsByTaskIdAndUserId(task.id(), targetUserId)) {
-            throw new TaskDomainException(TaskErrorCode.TASK_ALREADY_ASSIGNED);
-        }
-
-        try {
-            taskAssigneeRepository.save(TaskAssignee.assign(task.id(), targetUserId, actorId));
-        } catch (DataIntegrityViolationException exception) {
-            throw new TaskDomainException(TaskErrorCode.TASK_ALREADY_ASSIGNED);
-        }
-
-        return loadTaskDetail(task.id());
-    }
-
-    private TaskDetailResult unassignTaskInternal(Long projectId, Long taskId, Long actorId, Long targetUserId) {
-        validatePositiveId(projectId, "projectId");
-        validatePositiveId(taskId, "taskId");
-        validatePositiveId(actorId, "actorId");
-        validatePositiveId(targetUserId, "targetUserId");
-
-        ensureProjectMembership(projectId, actorId);
-        ensureAssignPermission(projectId, actorId);
-
-        Task task = loadTaskInProject(projectId, taskId);
-        task.ensureAssignableStatus();
-
-        TaskAssignee taskAssignee = taskAssigneeRepository.findByTaskIdAndUserId(task.id(), targetUserId)
-                .orElseThrow(() -> new TaskDomainException(TaskErrorCode.TASK_ASSIGNEE_NOT_ASSIGNED));
-
-        taskAssigneeRepository.delete(taskAssignee);
-
-        long remainingAssigneeCount = taskAssigneeRepository.countByTaskId(task.id());
-        if (remainingAssigneeCount == 0L) {
-            task.revertToPendingIfInProgress();
-        }
-
-        return loadTaskDetail(task.id());
+        return loadTaskDetail(task);
     }
 
     private Task loadTaskInProject(Long projectId, Long taskId) {
         Task task = taskRepository.findById(taskId)
                 .orElseThrow(() -> new TaskDomainException(TaskErrorCode.TASK_NOT_FOUND));
 
-        if (!Objects.equals(task.projectId(), projectId)) {
+        if (!task.belongsToProject(projectId)) {
             throw new TaskDomainException(TaskErrorCode.TASK_NOT_FOUND);
         }
 
         return task;
     }
 
-    private TaskDetailResult loadTaskDetail(Long taskId) {
-        return taskRepository.findDetailById(taskId)
-                .orElseThrow(() -> new TaskDomainException(
-                        TaskErrorCode.TASK_INTERNAL_SERVER_ERROR,
-                        "failed to load task detail"
-                ));
+    private TaskDetailResult loadTaskDetail(Task task) {
+        return new TaskDetailResult(
+                task.id(),
+                task.projectId(),
+                task.authorId(),
+                task.title(),
+                task.description(),
+                task.status(),
+                task.priority(),
+                task.startDate(),
+                task.dueDate(),
+                task.createdAt(),
+                task.updatedAt()
+        );
     }
 
     private void ensureProjectMembership(Long projectId, Long actorId) {
@@ -323,7 +391,7 @@ public class TaskCommandService {
     }
 
     private void ensureUpdatePermission(Task task, Long actorId) {
-        if (Objects.equals(task.authorId(), actorId)) {
+        if (task.isAuthor(actorId)) {
             return;
         }
 

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskAssignCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskAssignCommand.java
@@ -1,0 +1,9 @@
+package com.example.workmanagement.domain.task.service.command;
+
+public record TaskAssignCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId,
+        Long userId
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskAssignMeCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskAssignMeCommand.java
@@ -1,0 +1,8 @@
+package com.example.workmanagement.domain.task.service.command;
+
+public record TaskAssignMeCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskCancelStartCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskCancelStartCommand.java
@@ -1,0 +1,8 @@
+package com.example.workmanagement.domain.task.service.command;
+
+public record TaskCancelStartCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskCreateCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskCreateCommand.java
@@ -1,0 +1,15 @@
+package com.example.workmanagement.domain.task.service.command;
+
+import com.example.workmanagement.domain.task.domain.model.TaskPriority;
+import java.time.LocalDate;
+
+public record TaskCreateCommand(
+        Long projectId,
+        Long actorId,
+        String title,
+        String description,
+        LocalDate startDate,
+        LocalDate dueDate,
+        TaskPriority priority
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskForceCompleteCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskForceCompleteCommand.java
@@ -1,0 +1,8 @@
+package com.example.workmanagement.domain.task.service.command;
+
+public record TaskForceCompleteCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskStartCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskStartCommand.java
@@ -1,0 +1,8 @@
+package com.example.workmanagement.domain.task.service.command;
+
+public record TaskStartCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUnassignCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUnassignCommand.java
@@ -1,0 +1,9 @@
+package com.example.workmanagement.domain.task.service.command;
+
+public record TaskUnassignCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId,
+        Long userId
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUnassignMeCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUnassignMeCommand.java
@@ -1,0 +1,8 @@
+package com.example.workmanagement.domain.task.service.command;
+
+public record TaskUnassignMeCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUpdateDescriptionCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUpdateDescriptionCommand.java
@@ -1,0 +1,9 @@
+package com.example.workmanagement.domain.task.service.command;
+
+public record TaskUpdateDescriptionCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId,
+        String description
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUpdateDueDateCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUpdateDueDateCommand.java
@@ -1,0 +1,11 @@
+package com.example.workmanagement.domain.task.service.command;
+
+import java.time.LocalDate;
+
+public record TaskUpdateDueDateCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId,
+        LocalDate dueDate
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUpdatePriorityCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUpdatePriorityCommand.java
@@ -1,0 +1,11 @@
+package com.example.workmanagement.domain.task.service.command;
+
+import com.example.workmanagement.domain.task.domain.model.TaskPriority;
+
+public record TaskUpdatePriorityCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId,
+        TaskPriority priority
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUpdateStartDateCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUpdateStartDateCommand.java
@@ -1,0 +1,11 @@
+package com.example.workmanagement.domain.task.service.command;
+
+import java.time.LocalDate;
+
+public record TaskUpdateStartDateCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId,
+        LocalDate startDate
+) {
+}

--- a/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUpdateTitleCommand.java
+++ b/src/main/java/com/example/workmanagement/domain/task/service/command/TaskUpdateTitleCommand.java
@@ -1,0 +1,9 @@
+package com.example.workmanagement.domain.task.service.command;
+
+public record TaskUpdateTitleCommand(
+        Long projectId,
+        Long taskId,
+        Long actorId,
+        String title
+) {
+}

--- a/src/test/java/com/example/workmanagement/domain/task/presentation/TaskCommandControllerTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/presentation/TaskCommandControllerTest.java
@@ -1,0 +1,395 @@
+package com.example.workmanagement.domain.task.presentation;
+
+import com.example.workmanagement.domain.task.domain.model.TaskPriority;
+import com.example.workmanagement.domain.task.domain.model.TaskStatus;
+import com.example.workmanagement.domain.task.service.TaskCommandService;
+import com.example.workmanagement.domain.task.service.command.TaskAssignCommand;
+import com.example.workmanagement.domain.task.service.command.TaskAssignMeCommand;
+import com.example.workmanagement.domain.task.service.command.TaskCancelStartCommand;
+import com.example.workmanagement.domain.task.service.command.TaskCreateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskForceCompleteCommand;
+import com.example.workmanagement.domain.task.service.command.TaskStartCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUnassignCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUnassignMeCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateDescriptionCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateDueDateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdatePriorityCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateStartDateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateTitleCommand;
+import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
+import com.example.workmanagement.global.error.GlobalExceptionHandler;
+import com.example.workmanagement.global.security.resolver.AuthenticatedUserIdArgumentResolver;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class TaskCommandControllerTest {
+
+    @Mock
+    private TaskCommandService taskCommandService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        TaskCommandController controller = new TaskCommandController(taskCommandService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new AuthenticatedUserIdArgumentResolver())
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createTask_shouldResolveActorAndReturnCreated() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.PENDING);
+
+        when(taskCommandService.createTask(any(TaskCreateCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(post("/api/projects/{projectId}/tasks", 10L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "업무 제목",
+                                  "description": "업무 설명",
+                                  "startDate": "2026-03-17",
+                                  "dueDate": "2026-03-20",
+                                  "priority": "HIGH"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.taskId").value(100))
+                .andExpect(jsonPath("$.data.projectId").value(10));
+
+        ArgumentCaptor<TaskCreateCommand> captor = ArgumentCaptor.forClass(TaskCreateCommand.class);
+        verify(taskCommandService).createTask(captor.capture());
+        assertEquals(10L, captor.getValue().projectId());
+        assertEquals(101L, captor.getValue().actorId());
+        assertEquals("업무 제목", captor.getValue().title());
+    }
+
+    @Test
+    void assignTask_shouldMapRequestAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.PENDING);
+
+        when(taskCommandService.assignTask(any(TaskAssignCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(post("/api/projects/{projectId}/tasks/{taskId}/assign", 10L, 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": 102
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.taskId").value(100));
+
+        ArgumentCaptor<TaskAssignCommand> captor = ArgumentCaptor.forClass(TaskAssignCommand.class);
+        verify(taskCommandService).assignTask(captor.capture());
+        assertEquals(10L, captor.getValue().projectId());
+        assertEquals(100L, captor.getValue().taskId());
+        assertEquals(101L, captor.getValue().actorId());
+        assertEquals(102L, captor.getValue().userId());
+    }
+
+    @Test
+    void assignMe_shouldMapPathAndActorAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.PENDING);
+
+        when(taskCommandService.assignMe(any(TaskAssignMeCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(post("/api/projects/{projectId}/tasks/{taskId}/assign/me", 10L, 100L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.taskId").value(100));
+
+        ArgumentCaptor<TaskAssignMeCommand> captor = ArgumentCaptor.forClass(TaskAssignMeCommand.class);
+        verify(taskCommandService).assignMe(captor.capture());
+        assertEquals(10L, captor.getValue().projectId());
+        assertEquals(100L, captor.getValue().taskId());
+        assertEquals(101L, captor.getValue().actorId());
+    }
+
+    @Test
+    void unassignTask_shouldMapRequestAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.PENDING);
+
+        when(taskCommandService.unassignTask(any(TaskUnassignCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(post("/api/projects/{projectId}/tasks/{taskId}/unassign", 10L, 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": 102
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.taskId").value(100));
+
+        ArgumentCaptor<TaskUnassignCommand> captor = ArgumentCaptor.forClass(TaskUnassignCommand.class);
+        verify(taskCommandService).unassignTask(captor.capture());
+        assertEquals(10L, captor.getValue().projectId());
+        assertEquals(100L, captor.getValue().taskId());
+        assertEquals(101L, captor.getValue().actorId());
+        assertEquals(102L, captor.getValue().userId());
+    }
+
+    @Test
+    void unassignMe_shouldMapPathAndActorAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.PENDING);
+
+        when(taskCommandService.unassignMe(any(TaskUnassignMeCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(post("/api/projects/{projectId}/tasks/{taskId}/unassign/me", 10L, 100L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.taskId").value(100));
+
+        ArgumentCaptor<TaskUnassignMeCommand> captor = ArgumentCaptor.forClass(TaskUnassignMeCommand.class);
+        verify(taskCommandService).unassignMe(captor.capture());
+        assertEquals(10L, captor.getValue().projectId());
+        assertEquals(100L, captor.getValue().taskId());
+        assertEquals(101L, captor.getValue().actorId());
+    }
+
+    @Test
+    void updateTaskTitle_shouldMapRequestAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.PENDING);
+
+        when(taskCommandService.updateTitle(any(TaskUpdateTitleCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(patch("/api/projects/{projectId}/tasks/{taskId}/title", 10L, 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "수정 제목"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.taskId").value(100));
+
+        verify(taskCommandService).updateTitle(any(TaskUpdateTitleCommand.class));
+    }
+
+    @Test
+    void updateTaskDescription_shouldMapRequestAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.PENDING);
+
+        when(taskCommandService.updateDescription(any(TaskUpdateDescriptionCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(patch("/api/projects/{projectId}/tasks/{taskId}/description", 10L, 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "description": "수정 설명"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.taskId").value(100));
+
+        verify(taskCommandService).updateDescription(any(TaskUpdateDescriptionCommand.class));
+    }
+
+    @Test
+    void updateTaskStartDate_shouldMapRequestAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.PENDING);
+
+        when(taskCommandService.updateStartDate(any(TaskUpdateStartDateCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(patch("/api/projects/{projectId}/tasks/{taskId}/start-date", 10L, 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "startDate": "2026-03-21"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.taskId").value(100));
+
+        verify(taskCommandService).updateStartDate(any(TaskUpdateStartDateCommand.class));
+    }
+
+    @Test
+    void updateTaskDueDate_shouldMapRequestAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.PENDING);
+
+        when(taskCommandService.updateDueDate(any(TaskUpdateDueDateCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(patch("/api/projects/{projectId}/tasks/{taskId}/due-date", 10L, 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "dueDate": "2026-03-23"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.taskId").value(100));
+
+        verify(taskCommandService).updateDueDate(any(TaskUpdateDueDateCommand.class));
+    }
+
+    @Test
+    void updateTaskPriority_shouldMapRequestAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.PENDING);
+
+        when(taskCommandService.updatePriority(any(TaskUpdatePriorityCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(patch("/api/projects/{projectId}/tasks/{taskId}/priority", 10L, 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "priority": "LOW"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.taskId").value(100));
+
+        verify(taskCommandService).updatePriority(any(TaskUpdatePriorityCommand.class));
+    }
+
+    @Test
+    void startTask_shouldMapPathAndActorAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.IN_PROGRESS);
+
+        when(taskCommandService.startTask(any(TaskStartCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(post("/api/projects/{projectId}/tasks/{taskId}/start", 10L, 100L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"));
+
+        ArgumentCaptor<TaskStartCommand> captor = ArgumentCaptor.forClass(TaskStartCommand.class);
+        verify(taskCommandService).startTask(captor.capture());
+        assertEquals(10L, captor.getValue().projectId());
+        assertEquals(100L, captor.getValue().taskId());
+        assertEquals(101L, captor.getValue().actorId());
+    }
+
+    @Test
+    void forceCompleteTask_shouldMapPathAndActorAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.COMPLETED);
+
+        when(taskCommandService.forceCompleteTask(any(TaskForceCompleteCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(post("/api/projects/{projectId}/tasks/{taskId}/force-complete", 10L, 100L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
+
+        ArgumentCaptor<TaskForceCompleteCommand> captor = ArgumentCaptor.forClass(TaskForceCompleteCommand.class);
+        verify(taskCommandService).forceCompleteTask(captor.capture());
+        assertEquals(10L, captor.getValue().projectId());
+        assertEquals(100L, captor.getValue().taskId());
+        assertEquals(101L, captor.getValue().actorId());
+    }
+
+    @Test
+    void cancelStartTask_shouldMapPathAndActorAndReturnOk() throws Exception {
+        authenticateAs(101L);
+        TaskDetailResult detailResult = createTaskDetail(100L, 10L, TaskStatus.PENDING);
+
+        when(taskCommandService.cancelStartTask(any(TaskCancelStartCommand.class))).thenReturn(detailResult);
+
+        mockMvc.perform(post("/api/projects/{projectId}/tasks/{taskId}/cancel-start", 10L, 100L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("PENDING"));
+
+        ArgumentCaptor<TaskCancelStartCommand> captor = ArgumentCaptor.forClass(TaskCancelStartCommand.class);
+        verify(taskCommandService).cancelStartTask(captor.capture());
+        assertEquals(10L, captor.getValue().projectId());
+        assertEquals(100L, captor.getValue().taskId());
+        assertEquals(101L, captor.getValue().actorId());
+    }
+
+    @Test
+    void assignTask_withInvalidBody_shouldReturnBadRequest() throws Exception {
+        authenticateAs(101L);
+
+        mockMvc.perform(post("/api/projects/{projectId}/tasks/{taskId}/assign", 10L, 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": 0
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorInfo.code").value("INVALID_ARGUMENT"));
+
+        verifyNoInteractions(taskCommandService);
+    }
+
+    @Test
+    void createTask_whenUnauthenticated_shouldReturnUnauthorized() throws Exception {
+        SecurityContextHolder.clearContext();
+
+        mockMvc.perform(post("/api/projects/{projectId}/tasks", 10L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "업무 제목"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorInfo.code").value("USER_UNAUTHENTICATED"));
+
+        verifyNoInteractions(taskCommandService);
+    }
+
+    private void authenticateAs(Long userId) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(userId.toString(), "N/A", List.of()));
+        SecurityContextHolder.setContext(context);
+    }
+
+    private TaskDetailResult createTaskDetail(Long taskId, Long projectId, TaskStatus status) {
+        return new TaskDetailResult(
+                taskId,
+                projectId,
+                101L,
+                "업무 제목",
+                "업무 설명",
+                status,
+                TaskPriority.HIGH,
+                LocalDate.of(2026, 3, 17),
+                LocalDate.of(2026, 3, 20),
+                Instant.parse("2026-03-17T05:00:00Z"),
+                Instant.parse("2026-03-17T06:00:00Z")
+        );
+    }
+}

--- a/src/test/java/com/example/workmanagement/domain/task/presentation/TaskQueryControllerTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/presentation/TaskQueryControllerTest.java
@@ -69,7 +69,7 @@ class TaskQueryControllerTest {
 
         when(taskQueryService.findTask(10L, 100L, 101L)).thenReturn(detailResult);
 
-        mockMvc.perform(get("/api/v1/projects/{projectId}/tasks/{taskId}", 10L, 100L))
+        mockMvc.perform(get("/api/projects/{projectId}/tasks/{taskId}", 10L, 100L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.taskId").value(100))
                 .andExpect(jsonPath("$.data.projectId").value(10))
@@ -93,7 +93,7 @@ class TaskQueryControllerTest {
 
         when(taskQueryService.findTasks(eq(10L), eq(101L), isNull(), any(Pageable.class))).thenReturn(pageResult);
 
-        mockMvc.perform(get("/api/v1/projects/{projectId}/tasks", 10L))
+        mockMvc.perform(get("/api/projects/{projectId}/tasks", 10L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.page").value(0))
                 .andExpect(jsonPath("$.data.size").value(20))
@@ -122,7 +122,7 @@ class TaskQueryControllerTest {
 
         when(taskQueryService.findTasks(eq(10L), eq(101L), eq(statuses), any(Pageable.class))).thenReturn(pageResult);
 
-        mockMvc.perform(get("/api/v1/projects/{projectId}/tasks", 10L)
+        mockMvc.perform(get("/api/projects/{projectId}/tasks", 10L)
                         .param("statuses", "PENDING", "IN_PROGRESS")
                         .param("page", "1")
                         .param("size", "30")
@@ -142,7 +142,7 @@ class TaskQueryControllerTest {
     void getTask_whenUnauthenticated_shouldReturnUnauthorized() throws Exception {
         SecurityContextHolder.clearContext();
 
-        mockMvc.perform(get("/api/v1/projects/{projectId}/tasks/{taskId}", 10L, 100L))
+        mockMvc.perform(get("/api/projects/{projectId}/tasks/{taskId}", 10L, 100L))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorInfo.code").value("USER_UNAUTHENTICATED"));
 

--- a/src/test/java/com/example/workmanagement/domain/task/presentation/TaskQueryControllerTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/presentation/TaskQueryControllerTest.java
@@ -38,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
-class TaskControllerTest {
+class TaskQueryControllerTest {
 
     @Mock
     private TaskQueryService taskQueryService;
@@ -47,7 +47,7 @@ class TaskControllerTest {
 
     @BeforeEach
     void setUp() {
-        TaskController controller = new TaskController(taskQueryService);
+        TaskQueryController controller = new TaskQueryController(taskQueryService);
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .setCustomArgumentResolvers(

--- a/src/test/java/com/example/workmanagement/domain/task/repository/TaskAssigneeRepositoryDataJpaTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/repository/TaskAssigneeRepositoryDataJpaTest.java
@@ -1,0 +1,55 @@
+package com.example.workmanagement.domain.task.repository;
+
+import com.example.workmanagement.domain.task.domain.model.TaskAssignee;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DataJpaTest
+class TaskAssigneeRepositoryDataJpaTest {
+
+    @Autowired
+    private TaskAssigneeRepository taskAssigneeRepository;
+
+    @BeforeEach
+    void setUp() {
+        taskAssigneeRepository.deleteAll();
+    }
+
+    @Test
+    void existsAndFindByTaskIdAndUserId_shouldReturnAssignee() {
+        taskAssigneeRepository.saveAndFlush(TaskAssignee.assign(100L, 101L, 201L));
+
+        boolean exists = taskAssigneeRepository.existsByTaskIdAndUserId(100L, 101L);
+
+        assertTrue(exists);
+        assertTrue(taskAssigneeRepository.findByTaskIdAndUserId(100L, 101L).isPresent());
+    }
+
+    @Test
+    void countByTaskId_shouldCountOnlySameTask() {
+        taskAssigneeRepository.saveAndFlush(TaskAssignee.assign(100L, 101L, 201L));
+        taskAssigneeRepository.saveAndFlush(TaskAssignee.assign(100L, 102L, 201L));
+        taskAssigneeRepository.saveAndFlush(TaskAssignee.assign(200L, 103L, 201L));
+
+        long count = taskAssigneeRepository.countByTaskId(100L);
+
+        assertEquals(2L, count);
+    }
+
+    @Test
+    void saveDuplicateTaskAndUser_shouldThrowDataIntegrityViolationException() {
+        taskAssigneeRepository.saveAndFlush(TaskAssignee.assign(100L, 101L, 201L));
+
+        assertThrows(
+                DataIntegrityViolationException.class,
+                () -> taskAssigneeRepository.saveAndFlush(TaskAssignee.assign(100L, 101L, 202L))
+        );
+    }
+}

--- a/src/test/java/com/example/workmanagement/domain/task/service/TaskCommandServiceTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/service/TaskCommandServiceTest.java
@@ -13,7 +13,10 @@ import com.example.workmanagement.domain.task.repository.TaskAssigneeRepository;
 import com.example.workmanagement.domain.task.repository.TaskRepository;
 import com.example.workmanagement.domain.task.service.command.TaskAssignCommand;
 import com.example.workmanagement.domain.task.service.command.TaskAssignMeCommand;
+import com.example.workmanagement.domain.task.service.command.TaskCancelStartCommand;
 import com.example.workmanagement.domain.task.service.command.TaskCreateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskForceCompleteCommand;
+import com.example.workmanagement.domain.task.service.command.TaskStartCommand;
 import com.example.workmanagement.domain.task.service.command.TaskUnassignCommand;
 import com.example.workmanagement.domain.task.service.command.TaskUnassignMeCommand;
 import com.example.workmanagement.domain.task.service.command.TaskUpdateTitleCommand;
@@ -297,6 +300,219 @@ class TaskCommandServiceTest {
         assertSame(detail, result);
         assertEquals(TaskStatus.PENDING, getFieldValue(task, "status"));
         verify(taskAssigneeRepository).delete(taskAssignee);
+    }
+
+    @Test
+    void startTask_whenActorNotAssignee_shouldThrowForbidden() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.countByTaskId(100L)).thenReturn(1L);
+        when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 10L)).thenReturn(false);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.startTask(new TaskStartCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_START_FORBIDDEN, exception.errorCode());
+    }
+
+    @Test
+    void startTask_whenNoAssignee_shouldThrowTransitionNotAllowed() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.countByTaskId(100L)).thenReturn(0L);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.startTask(new TaskStartCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_STATUS_TRANSITION_NOT_ALLOWED, exception.errorCode());
+    }
+
+    @Test
+    void startTask_whenValid_shouldTransitionToInProgress() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
+        TaskDetailResult detail = createDetail(100L, 1L, 20L, "기존 제목", TaskStatus.IN_PROGRESS);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.countByTaskId(100L)).thenReturn(1L);
+        when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 10L)).thenReturn(true);
+        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
+
+        TaskDetailResult result = taskCommandService.startTask(new TaskStartCommand(1L, 100L, 10L));
+
+        assertSame(detail, result);
+        assertEquals(TaskStatus.IN_PROGRESS, getFieldValue(task, "status"));
+    }
+
+    @Test
+    void startTask_whenStatusNotPending_shouldThrowTransitionNotAllowed() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.IN_PROGRESS);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.countByTaskId(100L)).thenReturn(1L);
+        when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 10L)).thenReturn(true);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.startTask(new TaskStartCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_STATUS_TRANSITION_NOT_ALLOWED, exception.errorCode());
+    }
+
+    @Test
+    void startTask_whenNotProjectMember_shouldThrowForbidden() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.startTask(new TaskStartCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_PROJECT_MEMBERSHIP_REQUIRED, exception.errorCode());
+        verify(taskRepository, never()).findById(any());
+    }
+
+    @Test
+    void cancelStartTask_whenNotInProgress_shouldThrowTransitionNotAllowed() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 10L)).thenReturn(true);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.cancelStartTask(new TaskCancelStartCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_STATUS_TRANSITION_NOT_ALLOWED, exception.errorCode());
+    }
+
+    @Test
+    void cancelStartTask_whenActorNotAssignee_shouldThrowForbidden() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.IN_PROGRESS);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 10L)).thenReturn(false);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.cancelStartTask(new TaskCancelStartCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_START_FORBIDDEN, exception.errorCode());
+    }
+
+    @Test
+    void cancelStartTask_whenValid_shouldTransitionToPending() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.IN_PROGRESS);
+        TaskDetailResult detail = createDetail(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 10L)).thenReturn(true);
+        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
+
+        TaskDetailResult result = taskCommandService.cancelStartTask(new TaskCancelStartCommand(1L, 100L, 10L));
+
+        assertSame(detail, result);
+        assertEquals(TaskStatus.PENDING, getFieldValue(task, "status"));
+    }
+
+    @Test
+    void cancelStartTask_whenNotProjectMember_shouldThrowForbidden() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.cancelStartTask(new TaskCancelStartCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_PROJECT_MEMBERSHIP_REQUIRED, exception.errorCode());
+        verify(taskRepository, never()).findById(any());
+    }
+
+    @Test
+    void forceCompleteTask_whenNoPermission_shouldThrowForbidden() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_FORCE_COMPLETE)).thenReturn(false);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.forceCompleteTask(new TaskForceCompleteCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_FORCE_COMPLETE_FORBIDDEN, exception.errorCode());
+        verify(taskRepository, never()).findById(any());
+    }
+
+    @Test
+    void forceCompleteTask_whenValid_shouldTransitionToCompleted() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.IN_REVIEW);
+        TaskDetailResult detail = createDetail(100L, 1L, 20L, "기존 제목", TaskStatus.COMPLETED);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_FORCE_COMPLETE)).thenReturn(true);
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
+
+        TaskDetailResult result = taskCommandService.forceCompleteTask(new TaskForceCompleteCommand(1L, 100L, 10L));
+
+        assertSame(detail, result);
+        assertEquals(TaskStatus.COMPLETED, getFieldValue(task, "status"));
+    }
+
+    @Test
+    void forceCompleteTask_whenStatusNotInReview_shouldThrowTransitionNotAllowed() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.IN_PROGRESS);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_FORCE_COMPLETE)).thenReturn(true);
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.forceCompleteTask(new TaskForceCompleteCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_STATUS_TRANSITION_NOT_ALLOWED, exception.errorCode());
+    }
+
+    @Test
+    void forceCompleteTask_whenNotProjectMember_shouldThrowForbidden() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.forceCompleteTask(new TaskForceCompleteCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_PROJECT_MEMBERSHIP_REQUIRED, exception.errorCode());
+        verify(taskRepository, never()).findById(any());
     }
 
     private static TaskCreateCommand createCommand(Long projectId, Long actorId, String title) {

--- a/src/test/java/com/example/workmanagement/domain/task/service/TaskCommandServiceTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/service/TaskCommandServiceTest.java
@@ -33,7 +33,6 @@ import org.mockito.Mockito;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -86,18 +85,20 @@ class TaskCommandServiceTest {
 
     @Test
     void createTask_whenValid_shouldPersistAndReturnDetail() {
-        TaskDetailResult detail = createDetail(100L, 1L, 10L, "업무 제목", TaskStatus.PENDING);
         Task savedTask = createTask(100L, 1L, 10L, "업무 제목", TaskStatus.PENDING);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
         when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_CREATE)).thenReturn(true);
         when(taskRepository.save(any(Task.class))).thenReturn(savedTask);
-        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
 
         TaskDetailResult result = taskCommandService.createTask(createCommand(1L, 10L, "  업무 제목  "));
 
-        assertSame(detail, result);
+        assertEquals(100L, result.taskId());
+        assertEquals(1L, result.projectId());
+        assertEquals(10L, result.authorId());
+        assertEquals("업무 제목", result.title());
+        assertEquals(TaskStatus.PENDING, result.status());
 
         ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
         verify(taskRepository).save(taskCaptor.capture());
@@ -126,18 +127,17 @@ class TaskCommandServiceTest {
     @Test
     void updateTitle_whenAuthor_shouldUpdateAndReturnDetail() {
         Task task = createTask(100L, 1L, 10L, "기존 제목", TaskStatus.PENDING);
-        TaskDetailResult detail = createDetail(100L, 1L, 10L, "수정 제목", TaskStatus.PENDING);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
         when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
-        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
 
         TaskDetailResult result = taskCommandService.updateTitle(
                 new TaskUpdateTitleCommand(1L, 100L, 10L, "  수정 제목  ")
         );
 
-        assertSame(detail, result);
+        assertEquals(100L, result.taskId());
+        assertEquals("수정 제목", result.title());
         assertEquals("수정 제목", getFieldValue(task, "title"));
         verify(permissionChecker, never()).hasTaskPermission(eq(1L), eq(10L), eq(TaskPermission.TASK_OVERWRITE));
     }
@@ -242,17 +242,17 @@ class TaskCommandServiceTest {
     @Test
     void assignMe_whenValid_shouldCreateAssigneeWithActorId() {
         Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
-        TaskDetailResult detail = createDetail(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
         when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
         when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 10L)).thenReturn(false);
-        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
 
         TaskDetailResult result = taskCommandService.assignMe(new TaskAssignMeCommand(1L, 100L, 10L));
 
-        assertSame(detail, result);
+        assertEquals(100L, result.taskId());
+        assertEquals(1L, result.projectId());
+        assertEquals(TaskStatus.PENDING, result.status());
 
         ArgumentCaptor<TaskAssignee> assigneeCaptor = ArgumentCaptor.forClass(TaskAssignee.class);
         verify(taskAssigneeRepository).save(assigneeCaptor.capture());
@@ -314,18 +314,17 @@ class TaskCommandServiceTest {
     void unassignMe_whenInProgressLastAssignee_shouldRevertToPending() {
         Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.IN_PROGRESS);
         TaskAssignee taskAssignee = TaskAssignee.assign(100L, 10L, 20L);
-        TaskDetailResult detail = createDetail(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
         when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
         when(taskAssigneeRepository.findByTaskIdAndUserId(100L, 10L)).thenReturn(Optional.of(taskAssignee));
         when(taskAssigneeRepository.countByTaskId(100L)).thenReturn(0L);
-        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
 
         TaskDetailResult result = taskCommandService.unassignMe(new TaskUnassignMeCommand(1L, 100L, 10L));
 
-        assertSame(detail, result);
+        assertEquals(100L, result.taskId());
+        assertEquals(TaskStatus.PENDING, result.status());
         assertEquals(TaskStatus.PENDING, getFieldValue(task, "status"));
         verify(taskAssigneeRepository).delete(taskAssignee);
         verify(permissionChecker, never()).hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN);
@@ -383,18 +382,17 @@ class TaskCommandServiceTest {
     @Test
     void startTask_whenValid_shouldTransitionToInProgress() {
         Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
-        TaskDetailResult detail = createDetail(100L, 1L, 20L, "기존 제목", TaskStatus.IN_PROGRESS);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
         when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
         when(taskAssigneeRepository.countByTaskId(100L)).thenReturn(1L);
         when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 10L)).thenReturn(true);
-        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
 
         TaskDetailResult result = taskCommandService.startTask(new TaskStartCommand(1L, 100L, 10L));
 
-        assertSame(detail, result);
+        assertEquals(100L, result.taskId());
+        assertEquals(TaskStatus.IN_PROGRESS, result.status());
         assertEquals(TaskStatus.IN_PROGRESS, getFieldValue(task, "status"));
     }
 
@@ -467,17 +465,16 @@ class TaskCommandServiceTest {
     @Test
     void cancelStartTask_whenValid_shouldTransitionToPending() {
         Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.IN_PROGRESS);
-        TaskDetailResult detail = createDetail(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
         when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
         when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 10L)).thenReturn(true);
-        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
 
         TaskDetailResult result = taskCommandService.cancelStartTask(new TaskCancelStartCommand(1L, 100L, 10L));
 
-        assertSame(detail, result);
+        assertEquals(100L, result.taskId());
+        assertEquals(TaskStatus.PENDING, result.status());
         assertEquals(TaskStatus.PENDING, getFieldValue(task, "status"));
     }
 
@@ -513,17 +510,16 @@ class TaskCommandServiceTest {
     @Test
     void forceCompleteTask_whenValid_shouldTransitionToCompleted() {
         Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.IN_REVIEW);
-        TaskDetailResult detail = createDetail(100L, 1L, 20L, "기존 제목", TaskStatus.COMPLETED);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
         when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_FORCE_COMPLETE)).thenReturn(true);
         when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
-        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
 
         TaskDetailResult result = taskCommandService.forceCompleteTask(new TaskForceCompleteCommand(1L, 100L, 10L));
 
-        assertSame(detail, result);
+        assertEquals(100L, result.taskId());
+        assertEquals(TaskStatus.COMPLETED, result.status());
         assertEquals(TaskStatus.COMPLETED, getFieldValue(task, "status"));
     }
 

--- a/src/test/java/com/example/workmanagement/domain/task/service/TaskCommandServiceTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/service/TaskCommandServiceTest.java
@@ -4,12 +4,18 @@ import com.example.workmanagement.domain.project.entity.ProjectMember;
 import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
 import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
 import com.example.workmanagement.domain.task.domain.model.Task;
+import com.example.workmanagement.domain.task.domain.model.TaskAssignee;
 import com.example.workmanagement.domain.task.domain.model.TaskPriority;
 import com.example.workmanagement.domain.task.domain.model.TaskStatus;
 import com.example.workmanagement.domain.task.error.TaskErrorCode;
 import com.example.workmanagement.domain.task.exception.TaskDomainException;
+import com.example.workmanagement.domain.task.repository.TaskAssigneeRepository;
 import com.example.workmanagement.domain.task.repository.TaskRepository;
+import com.example.workmanagement.domain.task.service.command.TaskAssignCommand;
+import com.example.workmanagement.domain.task.service.command.TaskAssignMeCommand;
 import com.example.workmanagement.domain.task.service.command.TaskCreateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUnassignCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUnassignMeCommand;
 import com.example.workmanagement.domain.task.service.command.TaskUpdateTitleCommand;
 import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
 import com.example.workmanagement.global.authorization.PermissionChecker;
@@ -21,6 +27,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -34,10 +41,12 @@ import static org.mockito.Mockito.when;
 class TaskCommandServiceTest {
 
     private final TaskRepository taskRepository = Mockito.mock(TaskRepository.class);
+    private final TaskAssigneeRepository taskAssigneeRepository = Mockito.mock(TaskAssigneeRepository.class);
     private final ProjectMemberRepository projectMemberRepository = Mockito.mock(ProjectMemberRepository.class);
     private final PermissionChecker permissionChecker = Mockito.mock(PermissionChecker.class);
     private final TaskCommandService taskCommandService = new TaskCommandService(
             taskRepository,
+            taskAssigneeRepository,
             projectMemberRepository,
             permissionChecker
     );
@@ -74,8 +83,8 @@ class TaskCommandServiceTest {
 
     @Test
     void createTask_whenValid_shouldPersistAndReturnDetail() {
-        TaskDetailResult detail = createDetail(100L, 1L, 10L, "업무 제목");
-        Task savedTask = createTask(100L, 1L, 10L, "업무 제목");
+        TaskDetailResult detail = createDetail(100L, 1L, 10L, "업무 제목", TaskStatus.PENDING);
+        Task savedTask = createTask(100L, 1L, 10L, "업무 제목", TaskStatus.PENDING);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
@@ -89,13 +98,13 @@ class TaskCommandServiceTest {
 
         ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
         verify(taskRepository).save(taskCaptor.capture());
-        assertEquals("업무 제목", getTitle(taskCaptor.getValue()));
-        assertEquals(TaskStatus.PENDING, getStatus(taskCaptor.getValue()));
+        assertEquals("업무 제목", getFieldValue(taskCaptor.getValue(), "title"));
+        assertEquals(TaskStatus.PENDING, getFieldValue(taskCaptor.getValue(), "status"));
     }
 
     @Test
     void updateTitle_whenNotAuthorAndNoOverwritePermission_shouldThrowForbidden() {
-        Task task = createTask(100L, 1L, 30L, "기존 제목");
+        Task task = createTask(100L, 1L, 30L, "기존 제목", TaskStatus.PENDING);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
@@ -113,8 +122,8 @@ class TaskCommandServiceTest {
 
     @Test
     void updateTitle_whenAuthor_shouldUpdateAndReturnDetail() {
-        Task task = createTask(100L, 1L, 10L, "기존 제목");
-        TaskDetailResult detail = createDetail(100L, 1L, 10L, "수정 제목");
+        Task task = createTask(100L, 1L, 10L, "기존 제목", TaskStatus.PENDING);
+        TaskDetailResult detail = createDetail(100L, 1L, 10L, "수정 제목", TaskStatus.PENDING);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
@@ -126,24 +135,168 @@ class TaskCommandServiceTest {
         );
 
         assertSame(detail, result);
-        assertEquals("수정 제목", getTitle(task));
+        assertEquals("수정 제목", getFieldValue(task, "title"));
         verify(permissionChecker, never()).hasTaskPermission(eq(1L), eq(10L), eq(TaskPermission.TASK_OVERWRITE));
     }
 
     @Test
-    void updateTitle_whenProjectScopeMismatch_shouldThrowNotFound() {
-        Task task = createTask(100L, 2L, 10L, "기존 제목");
+    void assignTask_whenTargetNotProjectMember_shouldThrowForbidden() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 30L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN)).thenReturn(true);
         when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
 
         TaskDomainException exception = assertThrows(
                 TaskDomainException.class,
-                () -> taskCommandService.updateTitle(new TaskUpdateTitleCommand(1L, 100L, 10L, "수정 제목"))
+                () -> taskCommandService.assignTask(new TaskAssignCommand(1L, 100L, 10L, 30L))
         );
 
-        assertEquals(TaskErrorCode.TASK_NOT_FOUND, exception.errorCode());
+        assertEquals(TaskErrorCode.TASK_PROJECT_MEMBERSHIP_REQUIRED, exception.errorCode());
+        verify(taskAssigneeRepository, never()).save(any(TaskAssignee.class));
+    }
+
+    @Test
+    void assignTask_whenAlreadyAssigned_shouldThrowConflict() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 30L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN)).thenReturn(true);
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 30L)).thenReturn(true);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.assignTask(new TaskAssignCommand(1L, 100L, 10L, 30L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_ALREADY_ASSIGNED, exception.errorCode());
+        verify(taskAssigneeRepository, never()).save(any(TaskAssignee.class));
+    }
+
+    @Test
+    void assignTask_whenNoAssignPermission_shouldThrowForbidden() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN)).thenReturn(false);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.assignTask(new TaskAssignCommand(1L, 100L, 10L, 30L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_ASSIGN_FORBIDDEN, exception.errorCode());
+        verify(taskRepository, never()).findById(any());
+    }
+
+    @Test
+    void assignTask_whenTaskStatusCompleted_shouldThrowAssignmentNotAllowed() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.COMPLETED);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 30L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN)).thenReturn(true);
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.assignTask(new TaskAssignCommand(1L, 100L, 10L, 30L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_ASSIGNMENT_NOT_ALLOWED, exception.errorCode());
+        verify(taskAssigneeRepository, never()).save(any(TaskAssignee.class));
+    }
+
+    @Test
+    void assignTask_whenDuplicateInsertedByRace_shouldMapToAlreadyAssigned() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 30L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN)).thenReturn(true);
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 30L)).thenReturn(false);
+        when(taskAssigneeRepository.save(any(TaskAssignee.class))).thenThrow(new DataIntegrityViolationException("uk"));
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.assignTask(new TaskAssignCommand(1L, 100L, 10L, 30L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_ALREADY_ASSIGNED, exception.errorCode());
+    }
+
+    @Test
+    void assignMe_whenValid_shouldCreateAssigneeWithActorId() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
+        TaskDetailResult detail = createDetail(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN)).thenReturn(true);
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 10L)).thenReturn(false);
+        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
+
+        TaskDetailResult result = taskCommandService.assignMe(new TaskAssignMeCommand(1L, 100L, 10L));
+
+        assertSame(detail, result);
+
+        ArgumentCaptor<TaskAssignee> assigneeCaptor = ArgumentCaptor.forClass(TaskAssignee.class);
+        verify(taskAssigneeRepository).save(assigneeCaptor.capture());
+        assertEquals(100L, getFieldValue(assigneeCaptor.getValue(), "taskId"));
+        assertEquals(10L, getFieldValue(assigneeCaptor.getValue(), "userId"));
+        assertEquals(10L, getFieldValue(assigneeCaptor.getValue(), "assignedBy"));
+    }
+
+    @Test
+    void unassignTask_whenNotAssigned_shouldThrowConflict() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.IN_PROGRESS);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN)).thenReturn(true);
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.findByTaskIdAndUserId(100L, 30L)).thenReturn(Optional.empty());
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.unassignTask(new TaskUnassignCommand(1L, 100L, 10L, 30L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_ASSIGNEE_NOT_ASSIGNED, exception.errorCode());
+        verify(taskAssigneeRepository, never()).delete(any(TaskAssignee.class));
+    }
+
+    @Test
+    void unassignMe_whenInProgressLastAssignee_shouldRevertToPending() {
+        Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.IN_PROGRESS);
+        TaskAssignee taskAssignee = TaskAssignee.assign(100L, 10L, 20L);
+        TaskDetailResult detail = createDetail(100L, 1L, 20L, "기존 제목", TaskStatus.PENDING);
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN)).thenReturn(true);
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskAssigneeRepository.findByTaskIdAndUserId(100L, 10L)).thenReturn(Optional.of(taskAssignee));
+        when(taskAssigneeRepository.countByTaskId(100L)).thenReturn(0L);
+        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
+
+        TaskDetailResult result = taskCommandService.unassignMe(new TaskUnassignMeCommand(1L, 100L, 10L));
+
+        assertSame(detail, result);
+        assertEquals(TaskStatus.PENDING, getFieldValue(task, "status"));
+        verify(taskAssigneeRepository).delete(taskAssignee);
     }
 
     private static TaskCreateCommand createCommand(Long projectId, Long actorId, String title) {
@@ -158,14 +311,14 @@ class TaskCommandServiceTest {
         );
     }
 
-    private static TaskDetailResult createDetail(Long taskId, Long projectId, Long authorId, String title) {
+    private static TaskDetailResult createDetail(Long taskId, Long projectId, Long authorId, String title, TaskStatus status) {
         return new TaskDetailResult(
                 taskId,
                 projectId,
                 authorId,
                 title,
                 "설명",
-                TaskStatus.PENDING,
+                status,
                 TaskPriority.HIGH,
                 LocalDate.of(2026, 3, 17),
                 LocalDate.of(2026, 3, 20),
@@ -174,7 +327,7 @@ class TaskCommandServiceTest {
         );
     }
 
-    private static Task createTask(Long taskId, Long projectId, Long authorId, String title) {
+    private static Task createTask(Long taskId, Long projectId, Long authorId, String title, TaskStatus status) {
         Task task = Task.createNew(
                 projectId,
                 authorId,
@@ -184,35 +337,28 @@ class TaskCommandServiceTest {
                 LocalDate.of(2026, 3, 20),
                 TaskPriority.HIGH
         );
-        setId(task, taskId);
+        setFieldValue(task, "id", taskId);
+        setFieldValue(task, "status", status);
         return task;
     }
 
-    private static void setId(Task task, Long taskId) {
+    private static Object getFieldValue(Object target, String fieldName) {
         try {
-            Field idField = Task.class.getDeclaredField("id");
-            idField.setAccessible(true);
-            idField.set(task, taskId);
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(target);
         } catch (ReflectiveOperationException exception) {
-            throw new IllegalStateException("failed to set task id for test", exception);
+            throw new IllegalStateException("failed to read field: " + fieldName, exception);
         }
     }
 
-    private static String getTitle(Task task) {
-        return (String) getFieldValue(task, "title");
-    }
-
-    private static TaskStatus getStatus(Task task) {
-        return (TaskStatus) getFieldValue(task, "status");
-    }
-
-    private static Object getFieldValue(Task task, String fieldName) {
+    private static void setFieldValue(Object target, String fieldName, Object value) {
         try {
-            Field field = Task.class.getDeclaredField(fieldName);
+            Field field = target.getClass().getDeclaredField(fieldName);
             field.setAccessible(true);
-            return field.get(task);
+            field.set(target, value);
         } catch (ReflectiveOperationException exception) {
-            throw new IllegalStateException("failed to read task field: " + fieldName, exception);
+            throw new IllegalStateException("failed to set field: " + fieldName, exception);
         }
     }
 }

--- a/src/test/java/com/example/workmanagement/domain/task/service/TaskCommandServiceTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/service/TaskCommandServiceTest.java
@@ -1,0 +1,218 @@
+package com.example.workmanagement.domain.task.service;
+
+import com.example.workmanagement.domain.project.entity.ProjectMember;
+import com.example.workmanagement.domain.project.entity.ProjectMemberStatus;
+import com.example.workmanagement.domain.project.repository.ProjectMemberRepository;
+import com.example.workmanagement.domain.task.domain.model.Task;
+import com.example.workmanagement.domain.task.domain.model.TaskPriority;
+import com.example.workmanagement.domain.task.domain.model.TaskStatus;
+import com.example.workmanagement.domain.task.error.TaskErrorCode;
+import com.example.workmanagement.domain.task.exception.TaskDomainException;
+import com.example.workmanagement.domain.task.repository.TaskRepository;
+import com.example.workmanagement.domain.task.service.command.TaskCreateCommand;
+import com.example.workmanagement.domain.task.service.command.TaskUpdateTitleCommand;
+import com.example.workmanagement.domain.task.service.result.TaskDetailResult;
+import com.example.workmanagement.global.authorization.PermissionChecker;
+import com.example.workmanagement.global.authorization.permission.TaskPermission;
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TaskCommandServiceTest {
+
+    private final TaskRepository taskRepository = Mockito.mock(TaskRepository.class);
+    private final ProjectMemberRepository projectMemberRepository = Mockito.mock(ProjectMemberRepository.class);
+    private final PermissionChecker permissionChecker = Mockito.mock(PermissionChecker.class);
+    private final TaskCommandService taskCommandService = new TaskCommandService(
+            taskRepository,
+            projectMemberRepository,
+            permissionChecker
+    );
+
+    @Test
+    void createTask_whenNotProjectMember_shouldThrowForbidden() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.createTask(createCommand(1L, 10L, "업무 제목"))
+        );
+
+        assertEquals(TaskErrorCode.TASK_PROJECT_MEMBERSHIP_REQUIRED, exception.errorCode());
+        verify(permissionChecker, never()).hasTaskPermission(any(), any(), any());
+        verify(taskRepository, never()).save(any(Task.class));
+    }
+
+    @Test
+    void createTask_whenNoCreatePermission_shouldThrowForbidden() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_CREATE)).thenReturn(false);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.createTask(createCommand(1L, 10L, "업무 제목"))
+        );
+
+        assertEquals(TaskErrorCode.TASK_CREATE_FORBIDDEN, exception.errorCode());
+        verify(taskRepository, never()).save(any(Task.class));
+    }
+
+    @Test
+    void createTask_whenValid_shouldPersistAndReturnDetail() {
+        TaskDetailResult detail = createDetail(100L, 1L, 10L, "업무 제목");
+        Task savedTask = createTask(100L, 1L, 10L, "업무 제목");
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_CREATE)).thenReturn(true);
+        when(taskRepository.save(any(Task.class))).thenReturn(savedTask);
+        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
+
+        TaskDetailResult result = taskCommandService.createTask(createCommand(1L, 10L, "  업무 제목  "));
+
+        assertSame(detail, result);
+
+        ArgumentCaptor<Task> taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskRepository).save(taskCaptor.capture());
+        assertEquals("업무 제목", getTitle(taskCaptor.getValue()));
+        assertEquals(TaskStatus.PENDING, getStatus(taskCaptor.getValue()));
+    }
+
+    @Test
+    void updateTitle_whenNotAuthorAndNoOverwritePermission_shouldThrowForbidden() {
+        Task task = createTask(100L, 1L, 30L, "기존 제목");
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_OVERWRITE)).thenReturn(false);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.updateTitle(new TaskUpdateTitleCommand(1L, 100L, 10L, "새 제목"))
+        );
+
+        assertEquals(TaskErrorCode.TASK_UPDATE_FORBIDDEN, exception.errorCode());
+        verify(taskRepository, never()).findDetailById(any());
+    }
+
+    @Test
+    void updateTitle_whenAuthor_shouldUpdateAndReturnDetail() {
+        Task task = createTask(100L, 1L, 10L, "기존 제목");
+        TaskDetailResult detail = createDetail(100L, 1L, 10L, "수정 제목");
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+        when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
+
+        TaskDetailResult result = taskCommandService.updateTitle(
+                new TaskUpdateTitleCommand(1L, 100L, 10L, "  수정 제목  ")
+        );
+
+        assertSame(detail, result);
+        assertEquals("수정 제목", getTitle(task));
+        verify(permissionChecker, never()).hasTaskPermission(eq(1L), eq(10L), eq(TaskPermission.TASK_OVERWRITE));
+    }
+
+    @Test
+    void updateTitle_whenProjectScopeMismatch_shouldThrowNotFound() {
+        Task task = createTask(100L, 2L, 10L, "기존 제목");
+
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.updateTitle(new TaskUpdateTitleCommand(1L, 100L, 10L, "수정 제목"))
+        );
+
+        assertEquals(TaskErrorCode.TASK_NOT_FOUND, exception.errorCode());
+    }
+
+    private static TaskCreateCommand createCommand(Long projectId, Long actorId, String title) {
+        return new TaskCreateCommand(
+                projectId,
+                actorId,
+                title,
+                "설명",
+                LocalDate.of(2026, 3, 17),
+                LocalDate.of(2026, 3, 20),
+                TaskPriority.HIGH
+        );
+    }
+
+    private static TaskDetailResult createDetail(Long taskId, Long projectId, Long authorId, String title) {
+        return new TaskDetailResult(
+                taskId,
+                projectId,
+                authorId,
+                title,
+                "설명",
+                TaskStatus.PENDING,
+                TaskPriority.HIGH,
+                LocalDate.of(2026, 3, 17),
+                LocalDate.of(2026, 3, 20),
+                Instant.parse("2026-03-17T05:00:00Z"),
+                Instant.parse("2026-03-17T06:00:00Z")
+        );
+    }
+
+    private static Task createTask(Long taskId, Long projectId, Long authorId, String title) {
+        Task task = Task.createNew(
+                projectId,
+                authorId,
+                title,
+                "설명",
+                LocalDate.of(2026, 3, 17),
+                LocalDate.of(2026, 3, 20),
+                TaskPriority.HIGH
+        );
+        setId(task, taskId);
+        return task;
+    }
+
+    private static void setId(Task task, Long taskId) {
+        try {
+            Field idField = Task.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(task, taskId);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("failed to set task id for test", exception);
+        }
+    }
+
+    private static String getTitle(Task task) {
+        return (String) getFieldValue(task, "title");
+    }
+
+    private static TaskStatus getStatus(Task task) {
+        return (TaskStatus) getFieldValue(task, "status");
+    }
+
+    private static Object getFieldValue(Task task, String fieldName) {
+        try {
+            Field field = Task.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(task);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("failed to read task field: " + fieldName, exception);
+        }
+    }
+}

--- a/src/test/java/com/example/workmanagement/domain/task/service/TaskCommandServiceTest.java
+++ b/src/test/java/com/example/workmanagement/domain/task/service/TaskCommandServiceTest.java
@@ -246,7 +246,6 @@ class TaskCommandServiceTest {
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
-        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN)).thenReturn(true);
         when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
         when(taskAssigneeRepository.existsByTaskIdAndUserId(100L, 10L)).thenReturn(false);
         when(taskRepository.findDetailById(100L)).thenReturn(Optional.of(detail));
@@ -260,6 +259,21 @@ class TaskCommandServiceTest {
         assertEquals(100L, getFieldValue(assigneeCaptor.getValue(), "taskId"));
         assertEquals(10L, getFieldValue(assigneeCaptor.getValue(), "userId"));
         assertEquals(10L, getFieldValue(assigneeCaptor.getValue(), "assignedBy"));
+        verify(permissionChecker, never()).hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN);
+    }
+
+    @Test
+    void assignMe_whenNotProjectMember_shouldThrowForbidden() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.assignMe(new TaskAssignMeCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_PROJECT_MEMBERSHIP_REQUIRED, exception.errorCode());
+        verify(taskAssigneeRepository, never()).save(any(TaskAssignee.class));
     }
 
     @Test
@@ -282,6 +296,21 @@ class TaskCommandServiceTest {
     }
 
     @Test
+    void unassignTask_whenNoAssignPermission_shouldThrowForbidden() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
+        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN)).thenReturn(false);
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.unassignTask(new TaskUnassignCommand(1L, 100L, 10L, 30L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_ASSIGN_FORBIDDEN, exception.errorCode());
+        verify(taskRepository, never()).findById(any());
+    }
+
+    @Test
     void unassignMe_whenInProgressLastAssignee_shouldRevertToPending() {
         Task task = createTask(100L, 1L, 20L, "기존 제목", TaskStatus.IN_PROGRESS);
         TaskAssignee taskAssignee = TaskAssignee.assign(100L, 10L, 20L);
@@ -289,7 +318,6 @@ class TaskCommandServiceTest {
 
         when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(Mockito.mock(ProjectMember.class)));
-        when(permissionChecker.hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN)).thenReturn(true);
         when(taskRepository.findById(100L)).thenReturn(Optional.of(task));
         when(taskAssigneeRepository.findByTaskIdAndUserId(100L, 10L)).thenReturn(Optional.of(taskAssignee));
         when(taskAssigneeRepository.countByTaskId(100L)).thenReturn(0L);
@@ -300,6 +328,21 @@ class TaskCommandServiceTest {
         assertSame(detail, result);
         assertEquals(TaskStatus.PENDING, getFieldValue(task, "status"));
         verify(taskAssigneeRepository).delete(taskAssignee);
+        verify(permissionChecker, never()).hasTaskPermission(1L, 10L, TaskPermission.TASK_ASSIGN);
+    }
+
+    @Test
+    void unassignMe_whenNotProjectMember_shouldThrowForbidden() {
+        when(projectMemberRepository.findByProjectIdAndUserIdAndStatus(1L, 10L, ProjectMemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        TaskDomainException exception = assertThrows(
+                TaskDomainException.class,
+                () -> taskCommandService.unassignMe(new TaskUnassignMeCommand(1L, 100L, 10L))
+        );
+
+        assertEquals(TaskErrorCode.TASK_PROJECT_MEMBERSHIP_REQUIRED, exception.errorCode());
+        verify(taskAssigneeRepository, never()).delete(any(TaskAssignee.class));
     }
 
     @Test


### PR DESCRIPTION
> [!note]
> 변경 라인 수가 많긴 한데, 엔드포인트 개수가 많아서 그렇습니다(13개). 거의 유사한 논리 구조가 13 번 반복된다고 보시면 됩니다. 사실 상 2180 / 13 = 170 줄 가량의 난이도와 크게 다르지 않다고 말하는 것이 크게 무리는 아닐 수도 있을 것 같습니다.
> 1. 컨트롤러에서 request dto 로 요청 받음
> 2. command 로 mapping 하면서 sevice 메서드 호출
> 3. 자격 검증(권한 검증 포함)
> 4. CRUD
> 5. 별도 테스트 코드 작성